### PR TITLE
[RFC][NI] Remove styles that were breaking photo-gallery uniq styles

### DIFF
--- a/addon/components/uni-dropdown.js
+++ b/addon/components/uni-dropdown.js
@@ -1,9 +1,10 @@
 import Ember from 'ember';
 import layout from '../templates/components/uni-dropdown';
+import ClickOutsideMixin from 'ember-cli-uniq/mixins/click-outside';
 
 const { Component } = Ember;
 
-export default Component.extend({
+export default Component.extend(ClickOutsideMixin, {
   classNames: ['uni-dropdown'],
   classNameBindings: [
     'isOpen:uni-dropdown--active',
@@ -18,6 +19,10 @@ export default Component.extend({
   btnClass: '',
   onChange() {},
   onClick() {},
+
+  onOutsideClick() {
+    this.set('isOpen', false);
+  },
 
   actions: {
     buttonClick() {

--- a/addon/styles/partials/_uni-main-photo-picker.scss
+++ b/addon/styles/partials/_uni-main-photo-picker.scss
@@ -221,22 +221,5 @@
   &__wrapper {
     overflow: hidden;
     overflow-x: scroll;
-
-    &__item {
-        position: relative;
-
-        svg {
-            position: absolute;
-            top: 8px;
-            left: 10px;
-            width: 14px;
-            height: 14px;
-
-            &,
-            path {
-                fill: color('primary', 'highlight');
-            }
-        }
-    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-uniq",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Ember add-on with a variety of components with uniplaces-uniq styles and default behaviours.",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
After uniq update, this is breaking. Fixed by removing the styles that were only on ember-cli-uniq. 

@mmelo can you check this?

This is how it is looking now
![screen shot 2017-04-24 at 10 26 39](https://cloud.githubusercontent.com/assets/2593480/25331077/ab19fbfe-28d9-11e7-9efb-545ffac3aaf3.png)
