### PR TITLE
[RFC][UN-11305] Add description to uni header dropdown items

### DIFF
--- a/addon/components/uni-button-dropdown-item.js
+++ b/addon/components/uni-button-dropdown-item.js
@@ -1,0 +1,6 @@
+import Component from '@ember/component';
+import layout from '../templates/components/uni-button-dropdown-item';
+
+export default Component.extend({
+  layout
+});

--- a/addon/components/uni-button-dropdown.js
+++ b/addon/components/uni-button-dropdown.js
@@ -1,0 +1,32 @@
+import Component from '@ember/component';
+import layout from '../templates/components/uni-button-dropdown';
+import ClickOutsideMixin from 'ember-cli-uniq/mixins/click-outside';
+
+export default Component.extend(ClickOutsideMixin, {
+  tagName: 'span',
+  layout,
+  isOpen: false,
+  componentName: 'uni-button-dropdown-item',
+
+  switch() {},
+
+  actions: {
+    switch() {
+      this.set('isOpen', false);
+
+      this.get('switch')();
+    }
+  },
+
+  onOutsideClick() {
+    if (this.isComponentDestroyed()) {
+      return;
+    }
+
+    this.set('isOpen', false);
+  },
+
+  isComponentDestroyed() {
+    return this.get('isDestroyed') || this.get('isDestroying');
+  }
+});

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -5,6 +5,7 @@
         "partials/uni-button",
         "partials/uni-checkbox",
         "partials/uni-dropdown",
+        "partials/uni-button-dropdown",
         "partials/uni-file-upload",
         "partials/uni-info-box",
         "partials/uni-input-container",

--- a/addon/styles/partials/_uni-button-dropdown.scss
+++ b/addon/styles/partials/_uni-button-dropdown.scss
@@ -1,0 +1,128 @@
+.uni-button-dropdown {
+    position: relative;
+
+    &--active {
+        .uni-button-dropdown__list {
+            display: block;
+        }
+
+        .uni-button-dropdown__button {
+            &:before {
+                transform: rotate(45deg);
+            }
+
+            &:after {
+                transform: rotate(-45deg);
+            }
+        }
+    }
+
+    &__button {
+        position: relative;
+        align-items: center;
+        justify-content: center;
+        display: flex;
+        font-family: "IntervalNextReg", sans-serif;
+        min-width: 130px;
+        height: 44px;
+        padding: 0 22px;
+        max-width: 180px;
+        background-color: transparent;
+        border-radius: 2px;
+        border: none;
+        outline: none;
+        will-change: background-color;
+        font-size: 1rem;
+        text-align: center;
+        color: #00adef;
+        min-width: initial;
+        height: 38px;
+        font-family: "IntervalNextReg", sans-serif;
+        font-size: 0.9375rem;
+        color: #545d69;
+
+        &:before,
+        &:after {
+          content: " ";
+          position: absolute;
+          display: block;
+          width: 6px;
+          height: 2px;
+          top: calc(50% + 1px);
+          right: 8px;
+          background-color: #545d69;
+          transform: rotate(-45deg);
+          will-change: transform;
+      }
+
+      &:after {
+          right: 11px;
+          transform: rotate(45deg);
+      }
+    }
+
+    &__list {
+        position: absolute;
+        display: none;
+        width: 248px;
+        padding: 16px 0;
+        top: calc(100% + 11px);
+        right: 8px;
+        will-change: display;
+        backface-visibility: hidden;
+        background-color: #fff;
+        box-shadow: 0 16px 18px 0 rgba(31, 36, 50, 0.32);
+        border: solid 1px #ccd2d4;
+        border-radius: 2px;
+
+        &:before,
+        &:after {
+            content: " ";
+            position: absolute;
+            display: block;
+            width: 0;
+            height: 0;
+            top: -7px;
+            right: 16px;
+            z-index: 2;
+            border-bottom: 8px solid #fff;
+            border-left: 8px solid transparent;
+            border-right: 8px solid transparent;
+        }
+
+        &:after {
+            top: -8px;
+            z-index: 1;
+            border-bottom: 8px solid #ccd2d4;
+        }
+
+        &__item {
+            position: relative;
+            display: block;
+            width: 100%;
+            height: 32px;
+            line-height: 32px;
+            padding: 0 27px;
+            @include font("IntervalNextReg");
+            font-size: em(16px);
+            color: #545d69;
+
+            &:hover,
+            &--active {
+                cursor: pointer;
+                color: #00222f;
+
+                &:before {
+                    content: " ";
+                    position: absolute;
+                    display: block;
+                    left: 0;
+                    top: 0;
+                    width: 3px;
+                    height: 100%;
+                    background-color: color('primary');
+                }
+            }
+        }
+    }
+}

--- a/addon/templates/components/uni-button-dropdown-item.hbs
+++ b/addon/templates/components/uni-button-dropdown-item.hbs
@@ -1,0 +1,4 @@
+<li class="uni-button-dropdown__list__item" {{action onClick option.key}}>
+  <div class="uni-button-dropdown__list__item--value">{{option.value}}</div>
+  <div class="uni-button-dropdown__list__item--description">{{option.description}}</div>
+</li>

--- a/addon/templates/components/uni-button-dropdown.hbs
+++ b/addon/templates/components/uni-button-dropdown.hbs
@@ -1,0 +1,11 @@
+<div class="uni-button-dropdown {{if isOpen 'uni-button-dropdown--active'}}">
+    <div role="button" class="uni-button-dropdown__button" {{action (toggle "isOpen" this)}}>
+      {{selected}}
+    </div>
+
+    <ul class="uni-button-dropdown__list">
+      {{#each-in options as |k option|}}
+        {{yield componentName option}}
+      {{/each-in}}
+    </ul>
+</div>

--- a/app/components/uni-button-dropdown-item.js
+++ b/app/components/uni-button-dropdown-item.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-cli-uniq/components/uni-button-dropdown-item';

--- a/app/components/uni-button-dropdown.js
+++ b/app/components/uni-button-dropdown.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-cli-uniq/components/uni-button-dropdown';

--- a/tests/integration/components/uni-button-dropdown-item-test.js
+++ b/tests/integration/components/uni-button-dropdown-item-test.js
@@ -1,0 +1,34 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('uni-button-dropdown-item', 'Integration | Component | uni button dropdown item', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  assert.expect(2);
+
+  let expectedValue = 'Portugal';
+  let expectedDescription = 'Nice country';
+  this.set('option', { key: 'pt', value: expectedValue, description: expectedDescription });
+
+  this.render(hbs`{{uni-button-dropdown-item option=option}}`);
+
+  assert.equal(this.$('.uni-button-dropdown__list__item--value').text().trim(), expectedValue);
+  assert.equal(this.$('.uni-button-dropdown__list__item--description').text().trim(), expectedDescription);
+});
+
+test('it executes action when clicked', function(assert) {
+  assert.expect(1);
+
+  let expectedKey = 'pt';
+
+  this.set('clickAction', (key) => {
+    assert.equal(key, expectedKey);
+  });
+
+  this.set('option', { key: expectedKey, value: 'Portugal', description: 'Nice country' });
+
+  this.render(hbs`{{uni-button-dropdown-item option=option onClick=clickAction}}`);
+  this.$().click();
+});

--- a/tests/integration/components/uni-button-dropdown-test.js
+++ b/tests/integration/components/uni-button-dropdown-test.js
@@ -1,0 +1,16 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('uni-button-dropdown', 'Integration | Component | uni button dropdown', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  assert.expect(1);
+
+  this.set('selected', 'SELECTED');
+
+  this.render(hbs`{{uni-header-dropdown selected=selected}}`);
+
+  assert.equal(this.$().text().trim(), 'SELECTED');
+});


### PR DESCRIPTION
https://uniplaces.atlassian.net/browse/UN-11305

Why do I need this?

<img width="356" alt="screen shot 2017-12-26 at 11 43 57" src="https://user-images.githubusercontent.com/12813036/34358467-e67a8756-ea47-11e7-9598-02439346c0cf.png">

Basically, I've needed to implement the above component and I've realized that it's quite similar to ```uni-header-dropdown```with a description below the option. So instead of creating a new component, I've just adapted it. Perhaps the component's name isn't the best because it can be easily re-used in other contexts besides the header.

***UPDATE***
To avoid future errors, we've decided to create a new component, ```uni-button-dropdown```, that is just a copy of ```uni-header-dropdown``` with a minor change.

