### PR TITLE
[RFC][NI] Improve code snippets

### DIFF
--- a/addon/components/uni-datepicker.js
+++ b/addon/components/uni-datepicker.js
@@ -16,6 +16,7 @@ export default Component.extend({
   dateFormat: 'MMMM YYYY',
   showDaysAround: true,
   disabledDates: [],
+
   isFirstMonth: computed('center', function() {
     return this.get('center').isSame(this.get('minDate'), 'month') ? 'disabled' : '';
   }),

--- a/addon/components/uni-photo-thumbnail.js
+++ b/addon/components/uni-photo-thumbnail.js
@@ -12,7 +12,6 @@ const progressOptions = {
 };
 
 export default Component.extend({
-  onImageClick() {},
   progressOptions,
   layout,
 
@@ -21,10 +20,8 @@ export default Component.extend({
   }),
 
   imageStyle: computed('photo.url', function() {
-    if (!this.get('photo.url')) {
-      return htmlSafe('');
-    }
+    return htmlSafe(!this.get('photo.url') ? '' : `background-image: url(${this.get('photo.url')})`);
+  }),
 
-    return htmlSafe(`background-image: url(${this.get('photo.url')})`);
-  })
+  onImageClick() {}
 });

--- a/addon/templates/components/uni-datepicker.hbs
+++ b/addon/templates/components/uni-datepicker.hbs
@@ -3,7 +3,6 @@
   selected=selected
   onCenter=(action onCenter value="moment")
   onSelect=(action onSelect value="moment") as |calendar|}}
-
   <nav class="ember-power-calendar-nav">
     <div role="button" class="ember-power-calendar-nav-control {{isFirstMonth}}" {{action "prevMonth"}}>
       {{inline-svg "icons/arrow-left-calendar"}}

--- a/addon/templates/components/uni-photo-thumbnail.hbs
+++ b/addon/templates/components/uni-photo-thumbnail.hbs
@@ -1,6 +1,6 @@
 {{yield photo}}
 
-<div class="uni-image-gallery__wrapper__item__image {{if faded 'uni-image-gallery__wrapper__item__image--fade' ''}}" style={{imageStyle}} {{action onImageClick}}></div>
+<div class="uni-image-gallery__wrapper__item__image {{if faded 'uni-image-gallery__wrapper__item__image--fade'}}" style={{imageStyle}} {{action onImageClick}}></div>
 
 {{#if photo.isUploading}}
   <div class="uni-image-gallery__wrapper__item__progress">

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,6 +5,9 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
   let app = new EmberAddon(defaults, {
+    snippetPaths: [
+      'tests/dummy/app/templates/snippets'
+    ],
     sassOptions: {
       extension: 'scss'
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1842,6 +1842,59 @@
         }
       }
     },
+    "broccoli-static-compiler": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/broccoli-static-compiler/-/broccoli-static-compiler-0.1.4.tgz",
+      "integrity": "sha1-cT0Y8I6zExUwV1oMWtKVG7oQr0E=",
+      "dev": true,
+      "requires": {
+        "broccoli-kitchen-sink-helpers": "0.2.9",
+        "broccoli-writer": "0.1.1",
+        "mkdirp": "0.3.5"
+      },
+      "dependencies": {
+        "broccoli-kitchen-sink-helpers": {
+          "version": "0.2.9",
+          "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
+          "integrity": "sha1-peCYbtjXb7WYS2jD8EUNOpbjbsw=",
+          "dev": true,
+          "requires": {
+            "glob": "5.0.15",
+            "mkdirp": "0.5.1"
+          },
+          "dependencies": {
+            "mkdirp": {
+              "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "dev": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            }
+          }
+        },
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "mkdirp": {
+          "version": "0.3.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+          "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
+          "dev": true
+        }
+      }
+    },
     "broccoli-stew": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/broccoli-stew/-/broccoli-stew-1.5.0.tgz",
@@ -4488,6 +4541,43 @@
       "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
       "requires": {
         "semver": "5.4.0"
+      }
+    },
+    "ember-code-snippet": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ember-code-snippet/-/ember-code-snippet-2.0.0.tgz",
+      "integrity": "sha1-eeAGyYJBHcfrIb9aUf62bNNtfzs=",
+      "dev": true,
+      "requires": {
+        "broccoli-flatiron": "0.0.0",
+        "broccoli-merge-trees": "1.2.4",
+        "broccoli-static-compiler": "0.1.4",
+        "broccoli-writer": "0.1.1",
+        "es6-promise": "1.0.0",
+        "glob": "4.5.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "4.5.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+          "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "2.0.10",
+            "once": "1.4.0"
+          }
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        }
       }
     },
     "ember-composable-helpers": {
@@ -8397,6 +8487,12 @@
       "requires": {
         "is-arrayish": "0.2.1"
       }
+    },
+    "es6-promise": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-1.0.0.tgz",
+      "integrity": "sha1-+Q02KfqnwmFmrk33fIm6zeuNyn8=",
+      "dev": true
     },
     "escape-html": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "ember-cli-string-helpers": "^1.2.1",
     "ember-cli-test-loader": "^2.1.0",
     "ember-cli-uglify": "^2.0.0",
+    "ember-code-snippet": "2.0.0",
     "ember-composable-helpers": "2.0.1",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-disable-proxy-controllers": "^1.0.1",

--- a/tests/dummy/app/components/component-links.js
+++ b/tests/dummy/app/components/component-links.js
@@ -1,0 +1,8 @@
+import Component from '@ember/component';
+import layout from '../templates/components/component-links';
+
+export default Component.extend({
+  layout,
+  tagName: '',
+  path: 'https://github.com/uniplaces/ember-cli-uniq/blob/master/addon'
+});

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -144,18 +144,6 @@ body {
   line-height: 1.2;
 }
 
-.tab {
-  padding-left: 10px;
-}
-
-.double-tab {
-  padding-left: 20px;
-}
-
-.triple-tab {
-  padding-left: 30px;
-}
-
 .flex-wrapper {
   display: flex;
   align-items: left;
@@ -201,6 +189,10 @@ body {
 .uni-country,
 .uni-autocomplete {
   width: 300px;
+}
+
+.hljs {
+  padding: 16px;
 }
 
 @import "ember-power-calendar";

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -139,13 +139,6 @@ body {
   }
 }
 
-.code-snippet {
-  margin: 15px 0;
-  font-family: monospace;
-  font-size: em(18px);
-  line-height: 1.3;
-}
-
 .description {
   padding: 18px 0;
   line-height: 1.2;

--- a/tests/dummy/app/templates/components/component-links.hbs
+++ b/tests/dummy/app/templates/components/component-links.hbs
@@ -2,4 +2,6 @@
   <a target="_blank" href="{{i '${path}/components/${component}.js' path=path component=component}}">Javascript</a> |
   <a target="_blank" href="{{i '${path}/templates/components/${component}.hbs' path=path component=component}}">Handlebars</a> |
   <a target="_blank" href="{{i '${path}/styles/partials/_${component}.scss' path=path component=component}}">SASS</a>
+
+  {{yield component}}
 </p>

--- a/tests/dummy/app/templates/components/component-links.hbs
+++ b/tests/dummy/app/templates/components/component-links.hbs
@@ -1,0 +1,5 @@
+<p class="links">
+  <a target="_blank" href="{{i '${path}/components/${component}.js' path=path component=component}}">Javascript</a> |
+  <a target="_blank" href="{{i '${path}/templates/components/${component}.hbs' path=path component=component}}">Handlebars</a> |
+  <a target="_blank" href="{{i '${path}/styles/partials/_${component}.scss' path=path component=component}}">SASS</a>
+</p>

--- a/tests/dummy/app/templates/components/demo-page.hbs
+++ b/tests/dummy/app/templates/components/demo-page.hbs
@@ -23,7 +23,6 @@
         </p>
 
         {{uni-header}}
-
         {{code-snippet name="uni-header-1.hbs"}}
 
         {{#uni-header logoUrl="https://www.uniplaces.com"}}
@@ -33,13 +32,11 @@
             {{uni-header-button label="Sign up" isBordered=true}}
           {{/uni-header-menu}}
         {{/uni-header}}
-
         {{code-snippet name="uni-header-2.hbs"}}
 
         <div style="background-color: #333">
           {{uni-header isTransparent=true}}
         </div>
-
         {{code-snippet name="uni-header-3.hbs"}}
       </div>
     </div>
@@ -56,107 +53,67 @@
         {{#uni-horizontal-tabs options=model.options as |option|}}
           {{option}}
         {{/uni-horizontal-tabs}}
-
         {{code-snippet name="uni-horizontal-tabs-1.hbs"}}
 
         {{#uni-horizontal-tabs options=model.options btnLabel=model.uniHorizontalTabsBtnLabel as |option|}}
           {{option}}
         {{/uni-horizontal-tabs}}
-
         {{code-snippet name="uni-horizontal-tabs-2.hbs"}}
       </div>
 
       <div class="component">
         {{uni-title title="uni-tabs"}}
-        <p class="links">
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/components/uni-tabs.js">Javascript</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/templates/components/uni-tabs.hbs">Handlebars</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/styles/partials/_uni-tabs.scss">SASS</a>
-        </p>
+        {{component-links component="uni-tabs"}}
         <p class="description">
           This is a component used for header tabs. It receives an array of tabs consisting of objects containing a
           <strong>label</strong> and an <strong>url</strong>.<br><br>
           You can check an example of tabs <a class="uni-anchor" target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/tests/dummy/app/routes/application.js">here</a>.<br>
           <strong>WARNING: </strong>Currently it's only possible to use urls that are a route of the own application.
         </p>
-      </div>
 
-      {{uni-tabs tabs=model.tabs}}
-      <div class="component">
-        <p class="code-snippet">
-          \{{uni-tabs tabs=model.tabs}}
-        </p>
+        {{uni-tabs tabs=model.tabs}}
+        {{code-snippet name="uni-tabs-1.hbs"}}
       </div>
     </div>
 
     <div id="alerts" class="components__section">
       {{uni-title title="Alerts" class="uni-title--spaced"}}
       <div class="component">
-        <p class="links">
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/components/uni-alert.js">Javascript</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/templates/components/uni-alert.hbs">Handlebars</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/styles/partials/_uni-alert.scss">SASS</a>
-        </p>
+        {{component-links component="uni-alert"}}
         <p class="description">
-          This is a component used to generate alerts. There are four types of alerts: default (information), success, warning and error.
-          The <span class="code-snippet">type</span> of the alert can be passed by string - <span class="code-snippet">success, warning or error</span>
-          - or by setting custom variables - <span class="code-snippet">isSuccess, isWarning or isError</span>.
+          This is a component used to generate alerts. There are four types of alerts: default (information),
+          success, warning and error. The <code>type</code> of the alert can be passed by string - <code>success,
+          warning or error</code> - or by setting custom variables - <code>isSuccess, isWarning or isError</code>.
         </p>
-      </div>
 
-      {{uni-alert
-        stickyMode=true
-        hasClose=true
-        title="This is the default alert!"
-        subtitle="The stickyMode option and the hasClose option are also enabled."}}
-      <div class="component" style="margin-top: 60px;">
-        <p class="code-snippet">
-          \{{uni-alert<br>
-          <span class="tab">stickyMode=true</span><br>
-          <span class="tab">hasClose=true</span><br>
-          <span class="tab">title="This is the default alert!"</span><br>
-          <span class="tab">subtitle="The isFixed option and the hasClose option are also enabled."}}</span><br>
-        </p>
+        {{uni-alert
+          stickyMode=true
+          hasClose=true
+          title="This is the default alert!"
+          subtitle="The stickyMode option and the hasClose option are also enabled."}}
+        {{code-snippet name="uni-alert-1.hbs"}}
       </div>
 
       {{uni-alert type="success" title="Success!" subtitle="This is a subtitle."}}
-      <div class="component">
-        <p class="code-snippet">
-          \{{uni-alert type="success" title="Success!" subtitle="This is a subtitle."}}
-        </p>
-      </div>
+      {{code-snippet name="uni-alert-2.hbs"}}
 
-      {{uni-alert isWarning=true title="Warning!" subtitle="This is a subtitle."}}
-      <div class="component">
-        <p class="code-snippet">
-          \{{uni-alert isWarning=true title="Warning!" subtitle="This is a subtitle."}}
-        </p>
-      </div>
+      {{uni-alert type="warning" title="Warning!" subtitle="This is a subtitle."}}
+      {{code-snippet name="uni-alert-3.hbs"}}
 
       {{uni-alert isError=true title="Error!" subtitle="This is a subtitle."}}
-      <div class="component">
-        <p class="code-snippet">
-          \{{uni-alert isError=true title="Error!" subtitle="This is a subtitle."}}
-        </p>
-      </div>
+      {{code-snippet name="uni-alert-4.hbs"}}
     </div>
 
     <div id="progress-bar" class="components__section">
       {{uni-title title="Progress bar" class="uni-title--spaced"}}
       <div class="component">
-        <p class="links">
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/components/uni-progress-bar.js">Javascript</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/templates/components/uni-progress-bar.hbs">Handlebars</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/styles/partials/_uni-progress-bar.scss">SASS</a>
-        </p>
+        {{component-links component="uni-progress.bar"}}
         <p class="description">
           This is a component used to illustrate a progress for a determined flow. It takes as arguments a percentage and the total steps.
         </p>
 
         {{uni-progress-bar percentage=25 totalStepsCount=4}}
-        <p class="code-snippet">
-          \{{uni-progress-bar percentage=25 totalStepsCount=4}}
-        </p>
+        {{code-snippet name="uni-progress-bar-1.hbs"}}
       </div>
     </div>
 
@@ -164,11 +121,7 @@
       {{uni-title title="Headings" class="uni-title--spaced"}}
       <div class="component">
         {{uni-title title="uni-title"}}
-        <p class="links">
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/components/uni-title.js">Javascript</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/templates/components/uni-title.hbs">Handlebars</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/styles/partials/_uni-title.scss">SASS</a>
-        </p>
+        {{component-links component="uni-title"}}
         <p class="description">
           This is a component used to generate titles. It accepts a string (title) and an optional string (subtitle).
         </p>
@@ -186,11 +139,7 @@
 
       <div class="component">
         {{uni-title title="uni-subtitle"}}
-        <p class="links">
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/components/uni-subtitle.js">Javascript</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/templates/components/uni-subtitle.hbs">Handlebars</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/styles/partials/_uni-subtitle.scss">SASS</a>
-        </p>
+        {{component-links component="uni-subtitle"}}
         <p class="description">
           This is a component used to generate subtitles. It accepts a string (subtitle).
         </p>
@@ -205,11 +154,7 @@
     <div id="anchor" class="components__section">
       {{uni-title title="Anchor" class="uni-title--spaced"}}
       <div class="component">
-        <p class="links">
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/components/uni-anchor.js">Javascript</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/templates/components/uni-anchor.hbs">Handlebars</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/styles/partials/_uni-anchor.scss">SASS</a>
-        </p>
+        {{component-links component="uni-anchor"}}
         <p class="description">
           This is an anchor. This is implemented using <strong>a</strong> elements. For EmberJS transitions, use a
           <strong>linkTo</strong> component with the class 'uni-anchor'.
@@ -225,11 +170,7 @@
     <div id="buttons" class="components__section">
       {{uni-title title="Buttons" class="uni-title--spaced"}}
       <div class="component">
-        <p class="links">
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/components/uni-button.js">Javascript</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/templates/components/uni-button.hbs">Handlebars</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/styles/partials/_uni-button.scss">SASS</a>
-        </p>
+        {{component-links component="uni-button"}}
         <p class="description">
           This is a component used for all types of buttons. There are several types of buttons: primary, secondary, disabled
           and loading. It receives a label and an action that may or may not return a promise.<br>
@@ -244,24 +185,14 @@
           {{uni-button isPrimary=true isLoading=true label="Loading..."}}
         </div>
 
-        <p class="code-snippet">
-          \{{uni-button isPrimary=true label="Primary" action=(action "someAction")}}<br><br>
-          \{{uni-button isSecondary=true label="Secondary" action=(action "someAction")}}<br><br>
-          \{{uni-button isDisabled=true label="Disabled" action=(action "someAction")}}<br><br>
-          \{{uni-button isPrimary=true isLoading=true label="Loading..." action=(action "someAction")}}
-          <br><br>
-        </p>
+        {{code-snippet name="uni-button-1.hbs"}}
       </div>
     </div>
 
     <div id="checkbox" class="components__section">
       {{uni-title title="Checkbox" class="uni-title--spaced"}}
       <div class="component">
-        <p class="links">
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/components/uni-checkbox.js">Javascript</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/templates/components/uni-checkbox.hbs">Handlebars</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/styles/partials/_uni-checkbox.scss">SASS</a>
-        </p>
+        {{component-links component="uni-checkbox"}}
         <p class="description">
           This is a component used for checkbox inputs.
         </p>
@@ -272,13 +203,8 @@
           {{uni-checkbox label="Disabled checkbox" isDisabled=true}}
           {{uni-checkbox label="Checkbox with error" hasError=true}}
         </div>
-        <p class="code-snippet">
-          \{{uni-checkbox label="Selected" isSelected=true}}<br><br>
-          \{{uni-checkbox label="Not selected" isSelected=false}}<br><br>
-          \{{uni-checkbox label="Disabled checkbox" isDisabled=true}}<br><br>
-          \{{uni-checkbox label="Checkbox with error" hasError=true}}
-          <br><br>
-        </p>
+
+        {{code-snippet name="uni-checkbox-1.hbs"}}
       </div>
     </div>
 
@@ -287,11 +213,7 @@
 
       <div class="component">
         {{uni-title title="uni-datepicker"}}
-        <p class="links">
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/components/uni-datepicker.js">Javascript</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/templates/components/uni-datepicker.hbs">Handlebars</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/styles/partials/_uni-datepicker.scss">SASS</a>
-        </p>
+        {{component-links component="uni-datepicker"}}
         <p class="description">
           This is a calendar component.
         </p>
@@ -854,12 +776,7 @@
     <div id="footer" class="components__section">
       {{uni-title title="Footer" class="uni-title--spaced"}}
       <div class="component">
-        <p class="links">
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/components/uni-footer-website.js">Javascript</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/templates/components/uni-footer-website.hbs">Handlebars</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/styles/partials/_uni-footer-website.scss">SASS</a> |
-          <a target="_blank" href="https://github.com/uniplaces/uniplaces-uniq/blob/master/src/styles/_components/_footer.scss#L29">Uniq</a>
-        </p>
+        {{component-links component="uni-footer-website"}}
         <p class="description">
           This is the unified website footer component. As this may vary from platform to platform, this must be a very
           versatile component. This is composed of rows and cells.
@@ -867,88 +784,54 @@
       </div>
 
       {{#uni-footer-website as |footer|}}
-          {{#footer.row as |row|}}
-              {{#row.cell header="Uniplaces" as |cell|}}
-                  <a class="{{cell.cellClass}}__anchor">About</a>
-                  <a class="{{cell.cellClass}}__anchor">Partners</a>
-              {{/row.cell}}
-              {{#row.cell header="Students" as |cell|}}
-                  <a class="{{cell.cellClass}}__anchor">Ambassador program</a>
-                  <a class="{{cell.cellClass}}__anchor">Uniplaces scholarship</a>
-              {{/row.cell}}
-              {{#row.cell header="Need help?" as |cell|}}
-                  <a class="{{cell.cellClass}}__anchor">Help center</a>
-                  <a class="{{cell.cellClass}}__anchor">Contact us</a>
-              {{/row.cell}}
-          {{/footer.row}}
-          {{#footer.row as |row|}}
-              {{#row.cell halfLine=true as |cell|}}
-                  <a class="{{cell.cellClass}}__anchor {{cell.cellClass}}__anchor--inline">Lisbon</a>
-                  <a class="{{cell.cellClass}}__anchor {{cell.cellClass}}__anchor--inline">Porto</a>
-              {{/row.cell}}
-          {{/footer.row}}
+        {{#footer.row as |row|}}
+          {{#row.cell header="Uniplaces" as |cell|}}
+            <a class="{{cell.cellClass}}__anchor">About</a>
+            <a class="{{cell.cellClass}}__anchor">Partners</a>
+          {{/row.cell}}
+          {{#row.cell header="Students" as |cell|}}
+            <a class="{{cell.cellClass}}__anchor">Ambassador program</a>
+            <a class="{{cell.cellClass}}__anchor">Uniplaces scholarship</a>
+          {{/row.cell}}
+          {{#row.cell header="Need help?" as |cell|}}
+            <a class="{{cell.cellClass}}__anchor">Help center</a>
+            <a class="{{cell.cellClass}}__anchor">Contact us</a>
+          {{/row.cell}}
+        {{/footer.row}}
+        {{#footer.row as |row|}}
+          {{#row.cell halfLine=true as |cell|}}
+            <a class="{{cell.cellClass}}__anchor {{cell.cellClass}}__anchor--inline">Lisbon</a>
+            <a class="{{cell.cellClass}}__anchor {{cell.cellClass}}__anchor--inline">Porto</a>
+          {{/row.cell}}
+        {{/footer.row}}
       {{/uni-footer-website}}
 
-      <div class="component">
-        <p class="code-snippet">
-        \{{#uni-footer-website as |footer|}}<br>
-          <span class="tab">\{{#footer.row as |row|}}</span><br>
-              <span class="double-tab">\{{#row.cell header="Uniplaces" as |cell|}}</span><br>
-                <span class="triple-tab">&lt;a class="\{{cell.cellClass}}__anchor"&gt;About&lt;/a&gt;</span><br>
-                <span class="triple-tab">&lt;a class="\{{cell.cellClass}}__anchor"&gt;Partners&lt;/a&gt;</span><br>
-              <span class="double-tab">\{{/row.cell}}</span><br>
-              <span class="double-tab">\{{#row.cell header="Students" as |cell|}}</span><br>
-                <span class="triple-tab">&lt;a class="\{{cell.cellClass}}__anchor"&gt;Ambassador program&lt;/a&gt;</span><br>
-                <span class="triple-tab">&lt;a class="\{{cell.cellClass}}__anchor"&gt;Uniplaces scholarship&lt;/a&gt;</span><br>
-              <span class="double-tab">\{{/row.cell}}</span><br>
-              <span class="double-tab">\{{#row.cell header="Need help?" as |cell|}}</span><br>
-                <span class="triple-tab">&lt;a class="\{{cell.cellClass}}__anchor"&gt;Help center&lt;/a&gt;</span><br>
-                <span class="triple-tab">&lt;a class="\{{cell.cellClass}}__anchor"&gt;Contact us&lt;/a&gt;</span><br>
-              <span class="double-tab">\{{/row.cell}}</span><br>
-          <span class="tab">\{{/footer.row}}</span><br>
-          <span class="tab">\{{#footer.row as |row|}}</span><br>
-            <span class="double-tab">\{{#row.cell halfLine=true as |cell|}}</span><br>
-              <span class="triple-tab">&lt;a class="\{{cell.cellClass}}__anchor \{{cell.cellClass}}__anchor--inline"&gt;Lisbon&lt;/a&gt;</span><br>
-              <span class="triple-tab">&lt;a class="\{{cell.cellClass}}__anchor \{{cell.cellClass}}__anchor--inline"&gt;Porto&lt;/a&gt;</span><br>
-            <span class="double-tab">\{{/row.cell}}</span><br>
-          <span class="tab">\{{/footer.row}}</span><br>
-        \{{/uni-footer-website}}
-        </p>
-      </div>
+      {{code-snippet name="uni-footer-website-1.hbs"}}
 
       {{#uni-footer-website isDark=true as |footer|}}
-          {{#footer.row as |row|}}
-              {{#row.cell header="Uniplaces" as |cell|}}
-                  <a class="{{cell.cellClass}}__anchor">About</a>
-                  <a class="{{cell.cellClass}}__anchor">Partners</a>
-              {{/row.cell}}
-              {{#row.cell header="Students" as |cell|}}
-                  <a class="{{cell.cellClass}}__anchor">Ambassador program</a>
-                  <a class="{{cell.cellClass}}__anchor">Uniplaces scholarship</a>
-              {{/row.cell}}
-              {{#row.cell header="Need help?" as |cell|}}
-                  <a class="{{cell.cellClass}}__anchor">Help center</a>
-                  <a class="{{cell.cellClass}}__anchor">Contact us</a>
-              {{/row.cell}}
-          {{/footer.row}}
-          {{#footer.row as |row|}}
-              {{#row.cell halfLine=true as |cell|}}
-                  <a class="{{cell.cellClass}}__anchor {{cell.cellClass}}__anchor--inline">Lisbon</a>
-                  <a class="{{cell.cellClass}}__anchor {{cell.cellClass}}__anchor--inline">Porto</a>
-              {{/row.cell}}
-          {{/footer.row}}
+        {{#footer.row as |row|}}
+          {{#row.cell header="Uniplaces" as |cell|}}
+            <a class="{{cell.cellClass}}__anchor">About</a>
+            <a class="{{cell.cellClass}}__anchor">Partners</a>
+          {{/row.cell}}
+          {{#row.cell header="Students" as |cell|}}
+            <a class="{{cell.cellClass}}__anchor">Ambassador program</a>
+            <a class="{{cell.cellClass}}__anchor">Uniplaces scholarship</a>
+          {{/row.cell}}
+          {{#row.cell header="Need help?" as |cell|}}
+            <a class="{{cell.cellClass}}__anchor">Help center</a>
+            <a class="{{cell.cellClass}}__anchor">Contact us</a>
+          {{/row.cell}}
+        {{/footer.row}}
+        {{#footer.row as |row|}}
+          {{#row.cell halfLine=true as |cell|}}
+            <a class="{{cell.cellClass}}__anchor {{cell.cellClass}}__anchor--inline">Lisbon</a>
+            <a class="{{cell.cellClass}}__anchor {{cell.cellClass}}__anchor--inline">Porto</a>
+          {{/row.cell}}
+        {{/footer.row}}
       {{/uni-footer-website}}
 
-      <div class="component">
-        <p class="code-snippet">
-        \{{#uni-footer-website isDark=true as |footer|}}<br>
-          <span class="tab">\{{#footer.row as |row|}}</span><br>
-          <span class="double-tab">...</span><br>
-          <span class="tab">\{{/footer.row}}</span><br>
-        \{{/uni-footer-website}}
-        </p>
-      </div>
+      {{code-snippet name="uni-footer-website-2.hbs"}}
     </div>
-
   </div>
 </div>

--- a/tests/dummy/app/templates/components/demo-page.hbs
+++ b/tests/dummy/app/templates/components/demo-page.hbs
@@ -127,14 +127,10 @@
         </p>
 
         {{uni-title title="This is a title!"}}
-        <p class="code-snippet">
-          \{{uni-title title="This is a title!"}}
-        </p>
+        {{code-snippet name="uni-title-1.hbs"}}
 
         {{uni-title title="This is another title!" subtitle="with its own subtitle"}}
-        <p class="code-snippet">
-          \{{uni-title title="This is another title!" subtitle="with its own subtitle"}}
-        </p>
+        {{code-snippet name="uni-title-2.hbs"}}
       </div>
 
       <div class="component">
@@ -145,9 +141,7 @@
         </p>
 
         {{uni-subtitle subtitle="This is a subtitle"}}
-        <p class="code-snippet">
-          \{{uni-subtitle subtitle="This is a subtitle"}}
-        </p>
+        {{code-snippet name="uni-subtitle-1.hbs"}}
       </div>
     </div>
 
@@ -156,14 +150,12 @@
       <div class="component">
         {{component-links component="uni-anchor"}}
         <p class="description">
-          This is an anchor. This is implemented using <strong>a</strong> elements. For EmberJS transitions, use a
-          <strong>linkTo</strong> component with the class 'uni-anchor'.
+          This is an anchor. This is implemented using <code>a</code> elements. For EmberJS transitions, use a
+          <code>linkTo</code> component with the class 'uni-anchor'.
         </p>
 
         {{uni-anchor label="This is an anchor" href="//www.uniplaces.com" target="_blank"}}
-        <p class="code-snippet">
-          \{{uni-anchor label="This is an anchor" href="//www.uniplaces.com" target="_blank"}}
-        </p>
+        {{code-snippet name="uni-anchor-1.hbs"}}
       </div>
     </div>
 
@@ -184,7 +176,6 @@
           {{uni-button isDisabled=true label="Disabled"}}
           {{uni-button isPrimary=true isLoading=true label="Loading..."}}
         </div>
-
         {{code-snippet name="uni-button-1.hbs"}}
       </div>
     </div>
@@ -203,7 +194,6 @@
           {{uni-checkbox label="Disabled checkbox" isDisabled=true}}
           {{uni-checkbox label="Checkbox with error" hasError=true}}
         </div>
-
         {{code-snippet name="uni-checkbox-1.hbs"}}
       </div>
     </div>
@@ -226,11 +216,7 @@
 
       <div class="component">
         {{uni-title title="uni-datepicker-input"}}
-        <p class="links">
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/components/uni-datepicker-input.js">Javascript</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/templates/components/uni-datepicker-input.hbs">Handlebars</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/styles/partials/_uni-input.scss">SASS</a>
-        </p>
+        {{component-links component="uni-datepicker-input"}}
         <p class="description">
           This component shows a datepicker with the date as an input. It's also possible to open/close the datepicker
           by clicking on the input. You can provide a placeholder for the input.

--- a/tests/dummy/app/templates/components/demo-page.hbs
+++ b/tests/dummy/app/templates/components/demo-page.hbs
@@ -665,25 +665,23 @@
     <div id="tooltip" class="components__section">
       {{uni-title title="Tooltip" class="uni-title--spaced"}}
       <div class="component">
-        <p class="links">
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/components/uni-tooltip.js">Javascript</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/templates/components/uni-tooltip.hbs">Handlebars</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/styles/partials/_uni-tooltip.scss">SASS</a>
-        </p>
+        {{component-links component="uni-tooltip"}}
         <p class="description">
           This is a component used for displaying tooltips. There are currently two types of tooltips: question (isQuestion)
-          and informative (isInformation). The title is optional.
+          and informative (isInformation). The title is optional. You can also yield a component within the tooltip to
+          make it have a tooltip.
         </p>
 
         {{uni-tooltip isInformation=true content="This is a demo information tooltip text"}}
-        <p class="code-snippet">
-          \{{uni-tooltip isInformation=true content="This is a demo information tooltip text"}}
-        </p>
+        {{code-snippet name="uni-tooltip-1.hbs"}}
 
         {{uni-tooltip isQuestion=true title="Demo tooltip" content="This is a demo question tooltip content"}}
-        <p class="code-snippet">
-          \{{uni-tooltip isQuestion=true title="Demo tooltip" content="This is a demo question tooltip content"}}
-        </p>
+        {{code-snippet name="uni-tooltip-2.hbs"}}
+
+        {{#uni-tooltip content="Tooltip content about this button"}}
+          {{uni-button isDisabled=true label="Button with tooltip"}}
+        {{/uni-tooltip}}
+        {{code-snippet name="uni-tooltip-3.hbs"}}
       </div>
     </div>
 
@@ -723,11 +721,7 @@
       {{uni-title title="Rating" class="uni-title--spaced"}}
       <div class="component">
         {{uni-title title="uni-stars"}}
-        <p class="links">
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/components/uni-stars.js">Javascript</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/templates/components/uni-stars.hbs">Handlebars</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/styles/partials/_uni-stars.scss">SASS</a>
-        </p>
+        {{component-links component="uni-stars"}}
         <p class="description">
           Stars component to display grades.
         </p>
@@ -752,11 +746,7 @@
     <div id="information-box" class="components__section">
       {{uni-title title="Information box" class="uni-title--spaced"}}
       <div class="component">
-        <p class="links">
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/components/uni-info-box.js">Javascript</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/templates/components/uni-info-box.hbs">Handlebars</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/styles/partials/_uni-info-box.scss">SASS</a>
-        </p>
+        {{component-links component="uni-info-box"}}
         <p class="description">
           This information box is used to provide additional information to the user. Mainly used on the self-service platform.
         </p>
@@ -764,12 +754,7 @@
         {{#uni-info-box title="Type of place"}}
           The type of place and total area will let students know how big your place is.
         {{/uni-info-box}}
-
-        <p class="code-snippet">
-          \{{#uni-info-box title="Type of place"}}<br>
-            <span class="tab">The type of place and total area will let students know how big your place is.</span><br>
-          \{{/uni-info-box}}
-        </p>
+        {{code-snippet name="uni-info-box-1.hbs"}}
       </div>
     </div>
 

--- a/tests/dummy/app/templates/components/demo-page.hbs
+++ b/tests/dummy/app/templates/components/demo-page.hbs
@@ -13,6 +13,7 @@
   <div class="components">
     <div id="headers" class="components__section">
       {{uni-title title="Headers" class="uni-title--spaced"}}
+
       <div class="component">
         {{uni-title title="uni-header"}}
         {{component-links component="uni-header"}}
@@ -41,18 +42,13 @@
 
         {{code-snippet name="uni-header-3.hbs"}}
       </div>
-
     </div>
 
     <div id="tabs" class="components__section">
       {{uni-title title="Tabs" class="uni-title--spaced"}}
       <div class="component">
         {{uni-title title="uni-horizontal-tabs"}}
-        <p class="links">
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/components/uni-horizontal-tabs.js">Javascript</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/templates/components/uni-horizontal-tabs.hbs">Handlebars</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/styles/partials/_uni-horizontal-tabs.scss">SASS</a>
-        </p>
+        {{component-links component="uni-horizontal-tabs"}}
         <p class="description">
           This component allows to have horizontal tabs that switch the content on click.
         </p>
@@ -61,21 +57,13 @@
           {{option}}
         {{/uni-horizontal-tabs}}
 
-        <p class="code-snippet">
-          \{{#uni-horizontal-tabs options=options as |option|}}
-            <span class="tab">\{{option}}</span><br>
-          \{{/uni-horizontal-tabs}}
-        </p>
+        {{code-snippet name="uni-horizontal-tabs-1.hbs"}}
 
         {{#uni-horizontal-tabs options=model.options btnLabel=model.uniHorizontalTabsBtnLabel as |option|}}
           {{option}}
         {{/uni-horizontal-tabs}}
 
-        <p class="code-snippet">
-          \{{#uni-horizontal-tabs options=options btnLabel=model.uniHorizontalTabsBtnLabel as |option|}}
-            <span class="tab">\{{option}}</span><br>
-          \{{/uni-horizontal-tabs}}
-        </p>
+        {{code-snippet name="uni-horizontal-tabs-2.hbs"}}
       </div>
 
       <div class="component">

--- a/tests/dummy/app/templates/components/demo-page.hbs
+++ b/tests/dummy/app/templates/components/demo-page.hbs
@@ -209,9 +209,7 @@
         </p>
 
         {{uni-datepicker}}
-        <p class="code-snippet">
-          \{{uni-datepicker}}
-        </p>
+        {{code-snippet name="uni-datepicker-1.hbs"}}
       </div>
 
       <div class="component">
@@ -226,20 +224,14 @@
           selected=model.startDate
           minDate=model.minDate
           onSelected=(action (mut model.startDate))}}
-
-        <p class="code-snippet">
-          \{{uni-datepicker-input selected=startDate minDate=minDate onSelected=(action (mut startDate))}}
-        </p>
+        {{code-snippet name="uni-datepicker-input-1.hbs"}}
 
         {{uni-datepicker-input
           placeholder=model.datepickerInputPlaceholder
           selected=model.date
           minDate=model.minDate
           onSelected=(action (mut model.date))}}
-
-        <p class="code-snippet">
-          \{{uni-datepicker-input placeholder=placeholder selected=date minDate=minDate onSelected=(action (mut date))}}
-        </p>
+        {{code-snippet name="uni-datepicker-input-2.hbs"}}
 
         {{uni-datepicker-input
           label=model.datepickerInputLabel
@@ -248,21 +240,14 @@
           minDate=model.minDate
           onSelected=(action (mut model.date))
           disabledDates=model.disabledDates}}
-
-        <p class="code-snippet">
-          \{{uni-datepicker-input label=label placeholder=placeholder disabledDates=disabledDates selected=date minDate=minDate onSelected=(action (mut date))}}
-        </p>
+        {{code-snippet name="uni-datepicker-input-3.hbs"}}
       </div>
     </div>
 
     <div id="dropdown" class="components__section">
       {{uni-title title="Dropdown" class="uni-title--spaced"}}
       <div class="component">
-        <p class="links">
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/components/uni-dropdown.js">Javascript</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/templates/components/uni-dropdown.hbs">Handlebars</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/styles/partials/_uni-dropdown.scss">SASS</a>
-        </p>
+        {{component-links component="uni-dropdown"}}
         <p class="description">
           This is a component used for dropdown inputs. It accepts a placeholder, an array of options and a boolean to determine
           if it's positioned absolutely of relatively (this is related to the CSS property <strong>position</strong>).
@@ -276,16 +261,7 @@
           options=(array "Dropdown option 1" "Dropdown option 2" "Dropdown option 3") as |option|}}
           {{option}}
         {{/uni-dropdown}}
-
-        <p class="code-snippet">
-          \{{#uni-dropdown<br><br>
-            <span class="tab">isAbsolute=true</span><br><br>
-            <span class="tab">selected=selected</span><br><br>
-            <span class="tab">onChange=(action (mut selected))</span><br><br>
-            <span class="tab">options=(array "Dropdown option 1" "Dropdown option 2" "Dropdown option 3") as |option|}}</span><br><br>
-            <span class="tab">\{{option}}</span><br><br>
-          \{{/uni-dropdown}}
-        </p>
+        {{code-snippet name="uni-dropdown-1.hbs"}}
 
         <p class="description">
           This component also accepts an option to display a different alias for the selected option and an option to display svgs.
@@ -301,83 +277,46 @@
           options=model.dropdownOptions as |option|}}
           {{option.value}}
         {{/uni-dropdown}}
-
-        <p class="code-snippet">
-          \{{#uni-dropdown<br><br>
-            <span class="tab">isAbsolute=true</span><br><br>
-            <span class="tab">selected=selected</span><br><br>
-            <span class="tab">placeholder="Select one"</span><br><br>
-            <span class="tab">onChange=(action (mut selected))</span><br><br>
-            <span class="tab">selectedAlias=(i 'Alias example - ${selected}' selected=selected.value)</span><br><br>
-            <span class="tab">selectedSvgs=(if selected null (array 'icons/google' 'icons/facebook'))</span><br><br>
-            <span class="tab">options=dropdownOptions as |option|}}</span><br><br>
-            <span class="tab">\{{option}}</span><br><br>
-          \{{/uni-dropdown}}
-        </p>
+        {{code-snippet name="uni-dropdown-2.hbs"}}
       </div>
     </div>
 
     <div id="radio-button" class="components__section">
       {{uni-title title="Radio button" class="uni-title--spaced"}}
       <div class="component">
-        <p class="links">
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/components/uni-radio-button.js">Javascript</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/templates/components/uni-radio-button.hbs">Handlebars</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/styles/partials/_uni-radio-button.scss">SASS</a>
-        </p>
+        {{component-links component="uni-radio-button"}}
         <p class="description">
           This is a component used for radio button inputs.
         </p>
 
         {{uni-radio-button checked=true label="Checked radio button"}}
-        <p class="code-snippet">
-          \{{uni-radio-button checked=true label="Checked radio button"}}
-        </p>
-
         {{uni-radio-button checked=false label="Unchecked radio button"}}
-        <p class="code-snippet">
-          \{{uni-radio-button checked=false label="Unchecked radio button"}}
-        </p>
-
         {{uni-radio-button label="Disabled radio button" isDisabled=true}}
-        <p class="code-snippet">
-          \{{uni-radio-button label="Disabled radio button" isDisabled=true}}
-        </p>
+
+        {{code-snippet name="uni-radio-button-1.hbs"}}
       </div>
     </div>
 
     <div id="multi-selector" class="components__section">
       {{uni-title title="Multi selector" class="uni-title--spaced"}}
       <div class="component">
-        <p class="links">
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/components/uni-multi-selector.js">Javascript</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/templates/components/uni-multi-selector.hbs">Handlebars</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/styles/partials/_uni-multi-selector.scss">SASS</a>
-        </p>
+        {{component-links component="uni-multi-selector"}}
         <p class="description">
           This component is a visual alternative to the above radio buttons.
         </p>
 
         {{uni-multi-selector name="gender" options=model.genderOptions errorOptions=model.errorOptions isStatic=true}}
-        <p class="code-snippet">
-          \{{uni-multi-selector name="gender" options=options errorOptions=model.errorOptions isStatic=true}}
-        </p>
+        {{code-snippet name="uni-multi-selector-1.hbs"}}
 
         {{uni-multi-selector name="options" groupValue="option2" options=model.multiOptions}}
-        <p class="code-snippet">
-          \{{uni-multi-selector name="options" groupValue="option2" options=options}}
-        </p>
+        {{code-snippet name="uni-multi-selector-2.hbs"}}
       </div>
     </div>
 
     <div id="input" class="components__section">
       {{uni-title title="Input" class="uni-title--spaced"}}
       <div class="component">
-        <p class="links">
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/components/uni-input.js">Javascript</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/templates/components/uni-input.hbs">Handlebars</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/styles/partials/_uni-input.scss">SASS</a>
-        </p>
+        {{component-links component="uni-input"}}
         <p class="description">
           This is the default component used for inputs - it accepts the basic input options. <br>
           It has default validations for email and required empty fields - by default it shows error and does <u>not</u> show success.<br>
@@ -387,29 +326,19 @@
         </p>
 
         {{uni-input placeholder="Name" tooltipMessage="Click me!"}}
-        <p class="code-snippet">
-          \{{uni-input placeholder="Name" tooltipMessage="Click me!"}}
-        </p>
+        {{code-snippet name="uni-input-1.hbs"}}
 
         {{uni-input type="number" isRequired=true}}
-        <p class="code-snippet">
-          \{{uni-input type="number" isRequired=true}}
-        </p>
+        {{code-snippet name="uni-input-2.hbs"}}
 
         {{uni-input type="email" value=model.email}}
-        <p class="code-snippet">
-          \{{uni-input type="email" value=email}}
-        </p>
+        {{code-snippet name="uni-input-3.hbs"}}
 
         {{uni-input value=model.number showError=model.gteTen showSuccess=(not model.gteTen)}}
-        <p class="code-snippet">
-          \{{uni-input value=number showError=gteTen showSuccess=(not gteTen)}}
-        </p>
+        {{code-snippet name="uni-input-4.hbs"}}
 
         {{uni-input showSuccessDefault=true isRequired=true}}
-        <p class="code-snippet">
-          \{{uni-input showSuccessDefault=true isRequired=true}}
-        </p>
+        {{code-snippet name="uni-input-5.hbs"}}
       </div>
     </div>
 
@@ -417,11 +346,7 @@
       {{uni-title title="Special inputs" class="uni-title--spaced"}}
       <div class="component">
         {{uni-title title="uni-autocomplete"}}
-        <p class="links">
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/components/uni-autocomplete.js">Javascript</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/templates/components/uni-autocomplete.hbs">Handlebars</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/styles/partials/_uni-autocomplete.scss">SASS</a>
-        </p>
+        {{component-links component="uni-auto-complete"}}
         <p class="description">
           This is a component used for selecting an item for a list.
           <br>
@@ -440,16 +365,6 @@
           - <b>noResultsComponent</b>: optional, as long as you pass noResultsText everything is ok!
         </p>
 
-        <p class="code-snippet">
-          \{{#uni-autocomplete <br>
-            <span class="tab">options=model.autocompleteOptions</span><br>
-            <span class="tab">placeholderText="Type your coin"</span><br>
-            <span class="tab">searchTextValues=(action "onAutocompleteSearch")</span><br>
-            <span class="tab">onSelected=(action "onAutocompleteSelect") as |optionSearchable|}}</span><br><br>
-            <span class="tab">\{{optionSearchable.matchedValues.firstObject}}</span><br><br>
-          \{{/uni-autocomplete}}
-        </p>
-
         {{#uni-autocomplete
           options=model.autocompleteOptions
           placeholderText="Type your coin"
@@ -457,15 +372,12 @@
           onSelected=(action "onAutocompleteSelect") as |optionSearchable|}}
           {{titleize optionSearchable.matchedValues.firstObject}}
         {{/uni-autocomplete}}
+        {{code-snippet name="uni-autocomplete-1.hbs"}}
       </div>
 
       <div class="component">
         {{uni-title title="uni-country"}}
-        <p class="links">
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/components/uni-country.js">Javascript</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/templates/components/uni-country.hbs">Handlebars</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/styles/partials/_uni-country.scss">SASS</a>
-        </p>
+        {{component-links component="uni-country"}}
         <p class="description">
           This is a component used for selecting countries using our uni-autocomplete component.
           <br>
@@ -486,47 +398,31 @@
           - <b>getTranslatedCountryName</b>: a function that receives a key and a value and returns a string with the translated country name
         </p>
 
-        <p class="code-snippet">
-          \{{uni-country}}
-        </p>
         {{uni-country}}
+        {{code-snippet name="uni-country-1.hbs"}}
 
-        <p class="code-snippet">
-          \{{uni-country countryCode=model.countryCode hasError=(eq model.countryCode "PT")}}
-        </p>
         {{uni-country countryCode=model.countryCode hasError=(eq model.countryCode "PT")}}
+        {{code-snippet name="uni-country-2.hbs"}}
       </div>
 
       <div class="component">
         {{uni-title title="uni-input-range"}}
-        <p class="links">
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/components/uni-input-range.js">Javascript</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/templates/components/uni-input-range.hbs">Handlebars</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/styles/partials/_uni-input-range.scss">SASS</a>
-        </p>
+        {{component-links component="uni-input-range"}}
         <p class="description">
           This is a component used for number inputs. It accepts a placeholder, a value and a string with the description
           of the field (target). It can become editable by setting the isEditable flag to true.
         </p>
 
         {{uni-input-range placeholder="0" value="10" target="items"}}
-        <p class="code-snippet">
-          \{{uni-input-range placeholder="0" value="10" target="items"}}
-        </p>
+        {{code-snippet name="uni-input-range-1.hbs"}}
 
         {{uni-input-range placeholder="0" value="10" isEditable=true}}
-        <p class="code-snippet">
-          \{{uni-input-range placeholder="0" value="10" isEditable=true}}
-        </p>
+        {{code-snippet name="uni-input-range-2.hbs"}}
       </div>
 
       <div class="component">
         {{uni-title title="uni-input-price"}}
-        <p class="links">
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/components/uni-input-price.js">Javascript</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/templates/components/uni-input-price.hbs">Handlebars</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/styles/partials/_uni-input-price.scss">SASS</a>
-        </p>
+        {{component-links component="uni-input-price"}}
         <p class="description">
           This is a component used for price inputs, namely rent prices. It accepts the several properties, such as the currency
           (currency) and the basis (per). One improvement is to support left side currencies. Currently all currencies are
@@ -534,23 +430,15 @@
         </p>
 
         {{uni-input-price currency="€" per="month"}}
-        <p class="code-snippet">
-          \{{uni-input-price currency="€" per="month"}}
-        </p>
+        {{code-snippet name="uni-input-price-1.hbs"}}
 
         {{uni-input-price currency="€" per="month" isDisabled=true}}
-        <p class="code-snippet">
-          \{{uni-input-price currency="€" per="month" isDisabled=true}}
-        </p>
+        {{code-snippet name="uni-input-price-2.hbs"}}
       </div>
 
       <div class="component">
         {{uni-title title="uni-mobile-number"}}
-        <p class="links">
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/components/uni-mobile-number.js">Javascript</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/templates/components/uni-mobile-number.hbs">Handlebars</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/styles/partials/_uni-mobile-number.scss">SASS</a>
-        </p>
+        {{component-links component="uni-mobile-number"}}
         <p class="description">
           This is a component used for mobile number inputs, it accepts the several properties, such as an array of options
           (options) which by default is a list of all countries, and an optional array of preferred countries (preferredCountries).
@@ -559,62 +447,41 @@
         </p>
 
         {{uni-mobile-number}}
-        <p class="code-snippet">
-          \{{uni-mobile-number}}
-        </p>
+        {{code-snippet name="uni-mobile-number-1.hbs"}}
 
         {{uni-mobile-number preferredCountries=(array 'PT' 'DE' 'GB') tooltipMessage="There are preferred countries!"}}
-        <p class="code-snippet">
-          \{{uni-mobile-number preferredCountries=(array 'PT' 'DE' 'GB') tooltipMessage="There are preferred countries!"}}
-        </p>
+        {{code-snippet name="uni-mobile-number-2.hbs"}}
 
         {{uni-mobile-number selectPlaceholder='Select one' placeholder='Mobile number' preferredCountries=(array 'PT' 'DE' 'GB')}}
-        <p class="code-snippet">
-          \{{uni-mobile-number selectPlaceholder='Select one' placeholder='Mobile number' preferredCountries=(array 'PT' 'DE' 'GB')}}
-        </p>
+        {{code-snippet name="uni-mobile-number-3.hbs"}}
       </div>
 
       <div class="component">
         {{uni-title title="uni-file-upload"}}
-        <p class="links">
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/components/uni-file-upload.js">Javascript</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/templates/components/uni-file-upload.hbs">Handlebars</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/styles/partials/_uni-file-upload.scss">SASS</a>
-        </p>
+        {{component-links component="uni-file-upload"}}
         <p class="description">
           This is a component used to upload a single file.
         </p>
 
         {{uni-file-upload}}
-        <p class="code-snippet">
-          \{{uni-file-upload}}
-        </p>
+        {{code-snippet name="uni-file-upload-1.hbs"}}
       </div>
     </div>
 
     <div id="select" class="components__section">
       {{uni-title title="Select" class="uni-title--spaced"}}
       <div class="component">
-        <p class="links">
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/components/uni-select.js">Javascript</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/templates/components/uni-select.hbs">Handlebars</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/styles/partials/_uni-select.scss">SASS</a>
-        </p>
+        {{component-links component="uni-select"}}
         <p class="description">
-          This is a select input component. Check the <a class="uni-anchor" target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/tests/dummy/app/routes/application.js">application.js</a> for the uniSelectOptions array.
-          <br>
+          This is a select input component. Check the <a class="uni-anchor" target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/tests/dummy/app/routes/application.js">application.js</a> for the uniSelectOptions array.<br>
           You can set useAlias to true in order to display on the select a different value from the one on the option. For an example check uniSelectAliasOptions.
         </p>
 
         {{uni-select options=model.uniSelectOptions}}
-        <p class="code-snippet">
-          \{{uni-select options=options}}
-        </p>
+        {{code-snippet name="uni-select-1.hbs"}}
 
         {{uni-select placeholder="Choose an option" useAlias=true options=model.uniSelectAliasOptions}}
-        <p class="code-snippet">
-          \{{uni-select placeholder="Choose an option" useAlias=true options=aliasOptions}}
-        </p>
+        {{code-snippet name="uni-select-2.hbs"}}
       </div>
     </div>
 
@@ -622,29 +489,19 @@
 
       {{uni-title title="Textarea" class="uni-title--spaced"}}
       <div class="component">
-        <p class="links">
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/components/uni-textarea.js">Javascript</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/templates/components/uni-textarea.hbs">Handlebars</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/styles/partials/_uni-textarea.scss">SASS</a>
-        </p>
+        {{component-links component="uni-textarea"}}
         <p class="description">
           This is a textarea input component. It's allowed to define the number of rows and you can yield the characters count
           or some other component/text.
         </p>
 
         {{uni-textarea placeholder="This is a placeholder" tooltipMessage="I can have a tooltip!"}}
-        <p class="code-snippet">
-          \{{uni-textarea placeholder="This is a placeholder" tooltipMessage="I can have a tooltip!"}}
-        </p>
+        {{code-snippet name="uni-textarea-1.hbs"}}
 
         {{#uni-textarea placeholder="You can also count characters" as |count|}}
-          {{count}} characters
+          {{concat count " characters"}}
         {{/uni-textarea}}
-        <p class="code-snippet">
-          \{{#uni-textarea placeholder="You can also count characters" as |count|}}<br>
-          <span class="tab">\{{count}} characters</span><br>
-          \{{/uni-textarea}}
-        </p>
+        {{code-snippet name="uni-textarea-2.hbs"}}
       </div>
     </div>
 
@@ -676,11 +533,7 @@
 
       <div class="component">
         {{uni-title title="uni-main-photo-picker"}}
-        <p class="links">
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/components/uni-main-photo-picker.js">Javascript</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/templates/components/uni-main-photo-picker.hbs">Handlebars</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/styles/partials/_uni-main-photo-picker.scss">SASS</a>
-        </p>
+        {{component-links component="uni-main-photo-picker"}}
         <p class="description">
           Unified main photo picker component. Should not differ much from platform to platform and has custom
           action hooks for the main photo selection (from a pool of provided photos)
@@ -697,10 +550,7 @@
         </div>
       {{/uni-main-photo-picker}}
 
-      <p class="code-snippet">
-        \{{#uni-main-photo-picker title="Lorem ipsum dolor" photos=model.photos mainPhotoUrl=model.mainPhotoUrl as |photo|}}
-        \{{/uni-main-photo-picker}}
-      </p>
+      {{code-snippet name="uni-main-photo-picker-1.hbs"}}
     </div>
 
     <div id="rating" class="components__section">
@@ -713,19 +563,13 @@
         </p>
 
         {{uni-stars grade=2}}
-        <p class="code-snippet">
-          \{{uni-stars grade=2}}
-        </p>
+        {{code-snippet name="uni-stars-1.hbs"}}
 
         {{uni-stars grade=2.5}}
-        <p class="code-snippet">
-          \{{uni-stars grade=2.6}}
-        </p>
+        {{code-snippet name="uni-stars-2.hbs"}}
 
         {{uni-stars grade=2.5 maxStars=10}}
-        <p class="code-snippet">
-          \{{uni-stars grade=2.6 maxStars=10}}
-        </p>
+        {{code-snippet name="uni-stars-3.hbs"}}
       </div>
     </div>
 

--- a/tests/dummy/app/templates/components/demo-page.hbs
+++ b/tests/dummy/app/templates/components/demo-page.hbs
@@ -15,51 +15,33 @@
       {{uni-title title="Headers" class="uni-title--spaced"}}
       <div class="component">
         {{uni-title title="uni-header"}}
-        <p class="links">
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/components/uni-header.js">Javascript</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/templates/components/uni-header.hbs">Handlebars</a> |
-          <a target="_blank" href="https://github.com/uniplaces/ember-cli-uniq/blob/master/addon/styles/partials/_uni-header.scss">SASS</a>
-        </p>
+        {{component-links component="uni-header"}}
         <p class="description">
           This is a component used for the unified header. It's a straight forward component that must yield the desired
           components. See below for more insight.
         </p>
+
+        {{uni-header}}
+
+        {{code-snippet name="uni-header-1.hbs"}}
+
+        {{#uni-header logoUrl="https://www.uniplaces.com"}}
+          {{#uni-header-menu}}
+            {{uni-header-button label="Help" href="https://help.uniplaces.com"}}
+            {{uni-header-button label="Log in"}}
+            {{uni-header-button label="Sign up" isBordered=true}}
+          {{/uni-header-menu}}
+        {{/uni-header}}
+
+        {{code-snippet name="uni-header-2.hbs"}}
+
+        <div style="background-color: #333">
+          {{uni-header isTransparent=true}}
+        </div>
+
+        {{code-snippet name="uni-header-3.hbs"}}
       </div>
 
-      {{uni-header}}
-      <div class="component">
-        <p class="code-snippet">
-          \{{uni-header}}
-        </p>
-      </div>
-
-      {{#uni-header logoUrl="https://www.uniplaces.com"}}
-        {{#uni-header-menu}}
-          {{uni-header-button label="Help" href="https://help.uniplaces.com"}}
-          {{uni-header-button label="Log in"}}
-          {{uni-header-button label="Sign up" isBordered=true}}
-        {{/uni-header-menu}}
-      {{/uni-header}}
-      <div class="component">
-        <p class="code-snippet">
-          \{{#uni-header logoUrl="https://www.uniplaces.com"}}<br>
-            <span class="tab">\{{#uni-header-menu}}</span><br>
-              <span class="tab"><span class="tab">\{{uni-header-button label="Help" href="https://help.uniplaces.com"}}</span></span><br>
-              <span class="tab"><span class="tab">\{{uni-header-button label="Log in" action=yourRandomAction}}</span></span><br>
-              <span class="tab"><span class="tab">\{{uni-header-button label="Sign up" isBordered=true}}</span></span><br>
-            <span class="tab">\{{/uni-header-menu}}</span><br>
-          \{{/uni-header}}
-        </p>
-      </div>
-
-      <div style="background-color: #333">
-        {{uni-header isTransparent=true}}
-      </div>
-      <div class="component">
-        <p class="code-snippet">
-          \{{uni-header isTransparent=true}}
-        </p>
-      </div>
     </div>
 
     <div id="tabs" class="components__section">
@@ -797,6 +779,7 @@
 
     <div id="photos" class="components__section">
       {{uni-title title="Photos" class="uni-title--spaced"}}
+
       <div class="component">
         {{uni-title title="uni-main-photo-picker"}}
         <p class="links">
@@ -819,6 +802,7 @@
           Cover Photo
         </div>
       {{/uni-main-photo-picker}}
+
       <p class="code-snippet">
         \{{#uni-main-photo-picker title="Lorem ipsum dolor" photos=model.photos mainPhotoUrl=model.mainPhotoUrl as |photo|}}
         \{{/uni-main-photo-picker}}

--- a/tests/dummy/app/templates/snippets/uni-alert-1.hbs
+++ b/tests/dummy/app/templates/snippets/uni-alert-1.hbs
@@ -1,0 +1,5 @@
+{{uni-alert
+  stickyMode=true
+  hasClose=true
+  title="This is the default alert!"
+  subtitle="The stickyMode option and the hasClose option are also enabled."}}

--- a/tests/dummy/app/templates/snippets/uni-alert-2.hbs
+++ b/tests/dummy/app/templates/snippets/uni-alert-2.hbs
@@ -1,0 +1,1 @@
+{{uni-alert type="success" title="Success!" subtitle="This is a subtitle."}}

--- a/tests/dummy/app/templates/snippets/uni-alert-3.hbs
+++ b/tests/dummy/app/templates/snippets/uni-alert-3.hbs
@@ -1,0 +1,1 @@
+{{uni-alert isWarning=true title="Warning!" subtitle="This is a subtitle."}}

--- a/tests/dummy/app/templates/snippets/uni-alert-4.hbs
+++ b/tests/dummy/app/templates/snippets/uni-alert-4.hbs
@@ -1,0 +1,1 @@
+{{uni-alert isError=true title="Error!" subtitle="This is a subtitle."}}

--- a/tests/dummy/app/templates/snippets/uni-anchor-1.hbs
+++ b/tests/dummy/app/templates/snippets/uni-anchor-1.hbs
@@ -1,0 +1,1 @@
+{{uni-anchor label="This is an anchor" href="//www.uniplaces.com" target="_blank"}}

--- a/tests/dummy/app/templates/snippets/uni-autocomplete-1.hbs
+++ b/tests/dummy/app/templates/snippets/uni-autocomplete-1.hbs
@@ -1,0 +1,7 @@
+{{#uni-autocomplete
+  options=options
+  placeholderText="Type your coin"
+  searchTextValues=(action "onAutocompleteSearch")
+  onSelected=(action "onAutocompleteSelect") as |optionSearchable|}}
+  {{optionSearchable.matchedValues.firstObject}}
+{{/uni-autocomplete}}

--- a/tests/dummy/app/templates/snippets/uni-button-1.hbs
+++ b/tests/dummy/app/templates/snippets/uni-button-1.hbs
@@ -1,0 +1,4 @@
+{{uni-button isPrimary=true label="Primary"}}
+{{uni-button isSecondary=true label="Secondary"}}
+{{uni-button isDisabled=true label="Disabled"}}
+{{uni-button isPrimary=true isLoading=true label="Loading..."}}

--- a/tests/dummy/app/templates/snippets/uni-checkbox-1.hbs
+++ b/tests/dummy/app/templates/snippets/uni-checkbox-1.hbs
@@ -1,0 +1,4 @@
+{{uni-checkbox label="Selected" isSelected=true}}
+{{uni-checkbox label="Not selected" isSelected=false}}
+{{uni-checkbox label="Disabled checkbox" isDisabled=true}}
+{{uni-checkbox label="Checkbox with error" hasError=true}}

--- a/tests/dummy/app/templates/snippets/uni-country-1.hbs
+++ b/tests/dummy/app/templates/snippets/uni-country-1.hbs
@@ -1,0 +1,1 @@
+{{uni-country}}

--- a/tests/dummy/app/templates/snippets/uni-country-2.hbs
+++ b/tests/dummy/app/templates/snippets/uni-country-2.hbs
@@ -1,0 +1,1 @@
+{{uni-country countryCode=countryCode hasError=(eq countryCode "PT")}}

--- a/tests/dummy/app/templates/snippets/uni-datepicker-1.hbs
+++ b/tests/dummy/app/templates/snippets/uni-datepicker-1.hbs
@@ -1,0 +1,1 @@
+{{uni-datepicker}}

--- a/tests/dummy/app/templates/snippets/uni-datepicker-input-1.hbs
+++ b/tests/dummy/app/templates/snippets/uni-datepicker-input-1.hbs
@@ -1,0 +1,4 @@
+{{uni-datepicker-input
+  selected=startDate
+  minDate=minDate
+  onSelected=(action (mut startDate))}}

--- a/tests/dummy/app/templates/snippets/uni-datepicker-input-2.hbs
+++ b/tests/dummy/app/templates/snippets/uni-datepicker-input-2.hbs
@@ -1,0 +1,5 @@
+{{uni-datepicker-input
+  placeholder=placeholder
+  selected=date
+  minDate=minDate
+  onSelected=(action (mut date))}}

--- a/tests/dummy/app/templates/snippets/uni-datepicker-input-3.hbs
+++ b/tests/dummy/app/templates/snippets/uni-datepicker-input-3.hbs
@@ -1,0 +1,7 @@
+{{uni-datepicker-input
+  label=label
+  placeholder=placeholder
+  disabledDates=disabledDates
+  selected=date
+  minDate=minDate
+  onSelected=(action (mut date))}}

--- a/tests/dummy/app/templates/snippets/uni-dropdown-1.hbs
+++ b/tests/dummy/app/templates/snippets/uni-dropdown-1.hbs
@@ -1,0 +1,8 @@
+{{#uni-dropdown
+  isAbsolute=true
+  selected=dropdown.selected
+  placeholder="Select one"
+  onChange=(action (mut dropdown.selected))
+  options=(array "Dropdown option 1" "Dropdown option 2" "Dropdown option 3") as |option|}}
+  {{option}}
+{{/uni-dropdown}}

--- a/tests/dummy/app/templates/snippets/uni-dropdown-2.hbs
+++ b/tests/dummy/app/templates/snippets/uni-dropdown-2.hbs
@@ -1,0 +1,10 @@
+{{#uni-dropdown
+  isAbsolute=true
+  selected=selected
+  placeholder="Select one"
+  onChange=(action (mut selected))
+  selectedAlias=(i 'Alias example - ${selected}' selected=selected.value)
+  selectedSvgs=(if selected null (array 'icons/google' 'icons/facebook'))
+  options=dropdownOptions as |option|}}
+  {{option}}
+{{/uni-dropdown}}

--- a/tests/dummy/app/templates/snippets/uni-file-upload-1.hbs
+++ b/tests/dummy/app/templates/snippets/uni-file-upload-1.hbs
@@ -1,0 +1,1 @@
+{{uni-file-upload}}

--- a/tests/dummy/app/templates/snippets/uni-footer-website-1.hbs
+++ b/tests/dummy/app/templates/snippets/uni-footer-website-1.hbs
@@ -1,0 +1,22 @@
+{{#uni-footer-website as |footer|}}
+  {{#footer.row as |row|}}
+    {{#row.cell header="Uniplaces" as |cell|}}
+      <a class="{{cell.cellClass}}__anchor">About</a>
+      <a class="{{cell.cellClass}}__anchor">Partners</a>
+    {{/row.cell}}
+    {{#row.cell header="Students" as |cell|}}
+      <a class="{{cell.cellClass}}__anchor">Ambassador program</a>
+      <a class="{{cell.cellClass}}__anchor">Uniplaces scholarship</a>
+    {{/row.cell}}
+    {{#row.cell header="Need help?" as |cell|}}
+      <a class="{{cell.cellClass}}__anchor">Help center</a>
+      <a class="{{cell.cellClass}}__anchor">Contact us</a>
+    {{/row.cell}}
+  {{/footer.row}}
+  {{#footer.row as |row|}}
+    {{#row.cell halfLine=true as |cell|}}
+      <a class="{{cell.cellClass}}__anchor {{cell.cellClass}}__anchor--inline">Lisbon</a>
+      <a class="{{cell.cellClass}}__anchor {{cell.cellClass}}__anchor--inline">Porto</a>
+    {{/row.cell}}
+  {{/footer.row}}
+{{/uni-footer-website}}

--- a/tests/dummy/app/templates/snippets/uni-footer-website-2.hbs
+++ b/tests/dummy/app/templates/snippets/uni-footer-website-2.hbs
@@ -1,0 +1,22 @@
+{{#uni-footer-website isDark=true as |footer|}}
+  {{#footer.row as |row|}}
+    {{#row.cell header="Uniplaces" as |cell|}}
+      <a class="{{cell.cellClass}}__anchor">About</a>
+      <a class="{{cell.cellClass}}__anchor">Partners</a>
+    {{/row.cell}}
+    {{#row.cell header="Students" as |cell|}}
+      <a class="{{cell.cellClass}}__anchor">Ambassador program</a>
+      <a class="{{cell.cellClass}}__anchor">Uniplaces scholarship</a>
+    {{/row.cell}}
+    {{#row.cell header="Need help?" as |cell|}}
+      <a class="{{cell.cellClass}}__anchor">Help center</a>
+      <a class="{{cell.cellClass}}__anchor">Contact us</a>
+    {{/row.cell}}
+  {{/footer.row}}
+  {{#footer.row as |row|}}
+    {{#row.cell halfLine=true as |cell|}}
+      <a class="{{cell.cellClass}}__anchor {{cell.cellClass}}__anchor--inline">Lisbon</a>
+      <a class="{{cell.cellClass}}__anchor {{cell.cellClass}}__anchor--inline">Porto</a>
+    {{/row.cell}}
+  {{/footer.row}}
+{{/uni-footer-website}}

--- a/tests/dummy/app/templates/snippets/uni-header-1.hbs
+++ b/tests/dummy/app/templates/snippets/uni-header-1.hbs
@@ -1,0 +1,1 @@
+{{uni-header}}

--- a/tests/dummy/app/templates/snippets/uni-header-2.hbs
+++ b/tests/dummy/app/templates/snippets/uni-header-2.hbs
@@ -1,0 +1,7 @@
+{{#uni-header logoUrl="https://www.uniplaces.com"}}
+  {{#uni-header-menu}}
+    {{uni-header-button label="Help" href="https://help.uniplaces.com"}}
+    {{uni-header-button label="Log in"}}
+    {{uni-header-button label="Sign up" isBordered=true}}
+  {{/uni-header-menu}}
+{{/uni-header}}

--- a/tests/dummy/app/templates/snippets/uni-header-3.hbs
+++ b/tests/dummy/app/templates/snippets/uni-header-3.hbs
@@ -1,0 +1,1 @@
+{{uni-header isTransparent=true}}

--- a/tests/dummy/app/templates/snippets/uni-horizontal-tabs-1.hbs
+++ b/tests/dummy/app/templates/snippets/uni-horizontal-tabs-1.hbs
@@ -1,0 +1,3 @@
+{{#uni-horizontal-tabs options=options as |option|}}
+  {{option}}
+{{/uni-horizontal-tabs}}

--- a/tests/dummy/app/templates/snippets/uni-horizontal-tabs-2.hbs
+++ b/tests/dummy/app/templates/snippets/uni-horizontal-tabs-2.hbs
@@ -1,0 +1,3 @@
+{{#uni-horizontal-tabs options=options btnLabel=label as |option|}}
+  {{option}}
+{{/uni-horizontal-tabs}}

--- a/tests/dummy/app/templates/snippets/uni-info-box-1.hbs
+++ b/tests/dummy/app/templates/snippets/uni-info-box-1.hbs
@@ -1,0 +1,3 @@
+{{#uni-info-box title="Type of place"}}
+  The type of place and total area will let students know how big your place is.
+{{/uni-info-box}}

--- a/tests/dummy/app/templates/snippets/uni-input-1.hbs
+++ b/tests/dummy/app/templates/snippets/uni-input-1.hbs
@@ -1,0 +1,1 @@
+{{uni-input placeholder="Name" tooltipMessage="Click me!"}}

--- a/tests/dummy/app/templates/snippets/uni-input-2.hbs
+++ b/tests/dummy/app/templates/snippets/uni-input-2.hbs
@@ -1,0 +1,1 @@
+{{uni-input type="number" isRequired=true}}

--- a/tests/dummy/app/templates/snippets/uni-input-3.hbs
+++ b/tests/dummy/app/templates/snippets/uni-input-3.hbs
@@ -1,0 +1,1 @@
+{{uni-input type="email" value=email}}

--- a/tests/dummy/app/templates/snippets/uni-input-4.hbs
+++ b/tests/dummy/app/templates/snippets/uni-input-4.hbs
@@ -1,0 +1,1 @@
+{{uni-input value=number showError=gteTen showSuccess=(not gteTen)}}

--- a/tests/dummy/app/templates/snippets/uni-input-5.hbs
+++ b/tests/dummy/app/templates/snippets/uni-input-5.hbs
@@ -1,0 +1,1 @@
+{{uni-input showSuccessDefault=true isRequired=true}}

--- a/tests/dummy/app/templates/snippets/uni-input-price-1.hbs
+++ b/tests/dummy/app/templates/snippets/uni-input-price-1.hbs
@@ -1,0 +1,1 @@
+{{uni-input-price currency="€" per="month"}}

--- a/tests/dummy/app/templates/snippets/uni-input-price-2.hbs
+++ b/tests/dummy/app/templates/snippets/uni-input-price-2.hbs
@@ -1,0 +1,1 @@
+{{uni-input-price currency="€" per="month" isDisabled=true}}

--- a/tests/dummy/app/templates/snippets/uni-input-range-1.hbs
+++ b/tests/dummy/app/templates/snippets/uni-input-range-1.hbs
@@ -1,0 +1,1 @@
+{{uni-input-range placeholder="0" value="10" target="items"}}

--- a/tests/dummy/app/templates/snippets/uni-input-range-2.hbs
+++ b/tests/dummy/app/templates/snippets/uni-input-range-2.hbs
@@ -1,0 +1,1 @@
+{{uni-input-range placeholder="0" value="10" isEditable=true}}

--- a/tests/dummy/app/templates/snippets/uni-main-photo-picker-1.hbs
+++ b/tests/dummy/app/templates/snippets/uni-main-photo-picker-1.hbs
@@ -1,0 +1,9 @@
+{{#uni-main-photo-picker
+  title="Lorem ipsum dolor"
+  photos=photos
+  mainPhotoUrl=mainPhotoUrl as |photo|}}
+  <div class="uni-image-gallery__wrapper__item__main {{if (eq mainPhotoUrl photo.url) 'uni-image-gallery__wrapper__item__main--selected'}}" {{action "setAsMainPhoto" photo}}>
+    {{inline-svg (i "icons/main-photo-${type}.svg" type=(if (eq mainPhotoUrl photo.url) 'on' 'off'))}}
+    Cover Photo
+  </div>
+{{/uni-main-photo-picker}}

--- a/tests/dummy/app/templates/snippets/uni-mobile-number-1.hbs
+++ b/tests/dummy/app/templates/snippets/uni-mobile-number-1.hbs
@@ -1,0 +1,1 @@
+{{uni-mobile-number}}

--- a/tests/dummy/app/templates/snippets/uni-mobile-number-2.hbs
+++ b/tests/dummy/app/templates/snippets/uni-mobile-number-2.hbs
@@ -1,0 +1,1 @@
+{{uni-mobile-number preferredCountries=(array 'PT' 'DE' 'GB') tooltipMessage="There are preferred countries!"}}

--- a/tests/dummy/app/templates/snippets/uni-mobile-number-3.hbs
+++ b/tests/dummy/app/templates/snippets/uni-mobile-number-3.hbs
@@ -1,0 +1,4 @@
+{{uni-mobile-number
+  selectPlaceholder='Select one'
+  placeholder='Mobile number'
+  preferredCountries=(array 'PT' 'DE' 'GB')}}

--- a/tests/dummy/app/templates/snippets/uni-multi-selector-1.hbs
+++ b/tests/dummy/app/templates/snippets/uni-multi-selector-1.hbs
@@ -1,0 +1,1 @@
+{{uni-multi-selector name="gender" options=options errorOptions=model.errorOptions isStatic=true}}

--- a/tests/dummy/app/templates/snippets/uni-multi-selector-2.hbs
+++ b/tests/dummy/app/templates/snippets/uni-multi-selector-2.hbs
@@ -1,0 +1,1 @@
+{{uni-multi-selector name="options" groupValue="option2" options=options}}

--- a/tests/dummy/app/templates/snippets/uni-progress-bar-1.hbs
+++ b/tests/dummy/app/templates/snippets/uni-progress-bar-1.hbs
@@ -1,0 +1,1 @@
+{{uni-progress-bar percentage=25 totalStepsCount=4}}

--- a/tests/dummy/app/templates/snippets/uni-radio-button-1.hbs
+++ b/tests/dummy/app/templates/snippets/uni-radio-button-1.hbs
@@ -1,0 +1,3 @@
+{{uni-radio-button checked=true label="Checked radio button"}}
+{{uni-radio-button checked=false label="Unchecked radio button"}}
+{{uni-radio-button label="Disabled radio button" isDisabled=true}}

--- a/tests/dummy/app/templates/snippets/uni-select-1.hbs
+++ b/tests/dummy/app/templates/snippets/uni-select-1.hbs
@@ -1,0 +1,1 @@
+{{uni-select options=options}}

--- a/tests/dummy/app/templates/snippets/uni-select-2.hbs
+++ b/tests/dummy/app/templates/snippets/uni-select-2.hbs
@@ -1,0 +1,1 @@
+{{uni-select placeholder="Choose an option" useAlias=true options=aliasOptions}}

--- a/tests/dummy/app/templates/snippets/uni-stars-1.hbs
+++ b/tests/dummy/app/templates/snippets/uni-stars-1.hbs
@@ -1,0 +1,1 @@
+{{uni-stars grade=2}}

--- a/tests/dummy/app/templates/snippets/uni-stars-2.hbs
+++ b/tests/dummy/app/templates/snippets/uni-stars-2.hbs
@@ -1,0 +1,1 @@
+{{uni-stars grade=2.6}}

--- a/tests/dummy/app/templates/snippets/uni-stars-3.hbs
+++ b/tests/dummy/app/templates/snippets/uni-stars-3.hbs
@@ -1,0 +1,1 @@
+{{uni-stars grade=2.6 maxStars=10}}

--- a/tests/dummy/app/templates/snippets/uni-subtitle-1.hbs
+++ b/tests/dummy/app/templates/snippets/uni-subtitle-1.hbs
@@ -1,0 +1,1 @@
+{{uni-subtitle subtitle="This is a subtitle"}}

--- a/tests/dummy/app/templates/snippets/uni-tabs-1.hbs
+++ b/tests/dummy/app/templates/snippets/uni-tabs-1.hbs
@@ -1,0 +1,1 @@
+{{uni-tabs tabs=tabs}}

--- a/tests/dummy/app/templates/snippets/uni-textarea-1.hbs
+++ b/tests/dummy/app/templates/snippets/uni-textarea-1.hbs
@@ -1,0 +1,1 @@
+{{uni-textarea placeholder="This is a placeholder" tooltipMessage="I can have a tooltip!"}}

--- a/tests/dummy/app/templates/snippets/uni-textarea-2.hbs
+++ b/tests/dummy/app/templates/snippets/uni-textarea-2.hbs
@@ -1,0 +1,3 @@
+{{#uni-textarea placeholder="You can also count characters" as |count|}}
+  {{concat count " characters"}}
+{{/uni-textarea}}

--- a/tests/dummy/app/templates/snippets/uni-title-1.hbs
+++ b/tests/dummy/app/templates/snippets/uni-title-1.hbs
@@ -1,0 +1,1 @@
+{{uni-title title="This is a title!"}}

--- a/tests/dummy/app/templates/snippets/uni-title-2.hbs
+++ b/tests/dummy/app/templates/snippets/uni-title-2.hbs
@@ -1,0 +1,1 @@
+{{uni-title title="This is another title!" subtitle="with its own subtitle"}}

--- a/tests/dummy/app/templates/snippets/uni-tooltip-1.hbs
+++ b/tests/dummy/app/templates/snippets/uni-tooltip-1.hbs
@@ -1,0 +1,1 @@
+{{uni-tooltip isInformation=true content="This is a demo information tooltip text"}}

--- a/tests/dummy/app/templates/snippets/uni-tooltip-2.hbs
+++ b/tests/dummy/app/templates/snippets/uni-tooltip-2.hbs
@@ -1,0 +1,1 @@
+{{uni-tooltip isQuestion=true title="Demo tooltip" content="This is a demo question tooltip content"}}

--- a/tests/dummy/app/templates/snippets/uni-tooltip-3.hbs
+++ b/tests/dummy/app/templates/snippets/uni-tooltip-3.hbs
@@ -1,0 +1,3 @@
+{{#uni-tooltip content="Tooltip content about this button"}}
+  {{uni-button isDisabled=true label="Button with tooltip"}}
+{{/uni-tooltip}}


### PR DESCRIPTION
### Issue
NI

### What?
Improve code-snippets and links to component's files.

### Why?
The current code-snippets don't look very good. The tabs are done with padding (mea culpa) and there is no syntax highlighting what so ever. Also, we have to be constantly escaping handlebars code and the snippets are all over the demo-page.

### How?
Installing ember-code-snippet, we have an helper that, given a file, will make a code-snippet from it with syntax highlighting. Every snippet is now in a separate file, and can be accessed in an easier fashion.
Also, I created a component `{{component-links}}` that receives a component parameter (i.e. the name of the component) and renders the links to that component's files.

### Screenshots:
![screen shot 2018-01-03 at 11 00 02](https://user-images.githubusercontent.com/5813769/34518020-4b112f70-f075-11e7-8ed8-03b045148f27.png)

  