### PR TITLE
[RFC][NI] Use chrome with the --no-sandbox flag

### DIFF
--- a/testem.js
+++ b/testem.js
@@ -15,7 +15,8 @@ module.exports = {
         '--disable-gpu',
         '--headless',
         '--remote-debugging-port=9222',
-        '--window-size=1440,900'
+        '--window-size=1440,900',
+        '--no-sandbox'
       ]
     }
   }


### PR DESCRIPTION
### What is being fixed?
Tests have been failing on TravisCI with the following error:
```
30 11 2017 13:35:42.245:ERROR [launcher]: Cannot start Chrome
  [4315:4315:1130/133541.781662:FATAL:setuid_sandbox_host.cc(157)] The SUID sandbox helper binary was found, but is not configured correctly. Rather than run without sandboxing I'm aborting now. You need to make sure that /opt/google/chrome/chrome-sandbox is owned by root and has mode 4755.
```

After researching a bit, I found this problem being mentioned in the [Travis documentation about Chrome](https://docs.travis-ci.com/user/chrome#Sandboxing)