### PR TITLE
[RFC][UN-11823] Improve calendars and dropdowns in mobile

### DIFF
--- a/addon/components/uni-dropdown.js
+++ b/addon/components/uni-dropdown.js
@@ -21,6 +21,7 @@ export default Component.extend(ClickOutsideMixin, {
   buttonErrorClass: 'uni-dropdown__button--error',
   options: [],
   btnClass: '',
+  isNativeOnMobile: false,
 
   errorClass: computed('hasError', function() {
     return this.get('hasError') ? this.get('buttonErrorClass') : '';

--- a/addon/components/uni-dropdown.js
+++ b/addon/components/uni-dropdown.js
@@ -1,9 +1,12 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
 import layout from '../templates/components/uni-dropdown';
 import ClickOutsideMixin from 'ember-cli-uniq/mixins/click-outside';
 
 export default Component.extend(ClickOutsideMixin, {
+  media: service(),
+
   classNames: ['uni-dropdown'],
   classNameBindings: [
     'isOpen:uni-dropdown--active',
@@ -12,6 +15,7 @@ export default Component.extend(ClickOutsideMixin, {
   ],
   layout,
 
+  useAlias: false,
   selectedAlias: null,
   selectedSvgs: null,
   isOpen: false,
@@ -21,7 +25,8 @@ export default Component.extend(ClickOutsideMixin, {
   buttonErrorClass: 'uni-dropdown__button--error',
   options: [],
   btnClass: '',
-  isNativeOnMobile: false,
+
+  isNativeOnMobile: computed.alias('media.isMobile'),
 
   errorClass: computed('hasError', function() {
     return this.get('hasError') ? this.get('buttonErrorClass') : '';

--- a/addon/components/uni-dropdown.js
+++ b/addon/components/uni-dropdown.js
@@ -26,8 +26,6 @@ export default Component.extend(ClickOutsideMixin, {
   options: [],
   btnClass: '',
 
-  isNativeOnMobile: computed.alias('media.isMobile'),
-
   errorClass: computed('hasError', function() {
     return this.get('hasError') ? this.get('buttonErrorClass') : '';
   }),

--- a/addon/styles/partials/_uni-dropdown.scss
+++ b/addon/styles/partials/_uni-dropdown.scss
@@ -30,4 +30,10 @@
       height: 100%;
     }
   }
+
+  &__button--native-mobile {
+    position: relative;
+    height: 100%;
+    font-size: em(14px);
+  }
 }

--- a/addon/styles/partials/_uni-dropdown.scss
+++ b/addon/styles/partials/_uni-dropdown.scss
@@ -30,10 +30,4 @@
       height: 100%;
     }
   }
-
-  &__button--native-mobile {
-    position: relative;
-    height: 100%;
-    font-size: em(14px);
-  }
 }

--- a/addon/templates/components/uni-dropdown.hbs
+++ b/addon/templates/components/uni-dropdown.hbs
@@ -1,9 +1,5 @@
 {{#if isNativeOnMobile}}
-  <select class="{{btnClass}} uni-dropdown__button uni-dropdown__button--native-mobile {{errorClass}}" onchange={{action "optionClick" option=target.value}}>
-    {{#each options as |option|}}
-      <option value="{{if option.value option.value option}}">{{yield option}}</option>
-    {{/each}}
-  </select>
+  {{uni-select options=options useAlias=useAlias placeholder=placeholder}}
 {{else}}
   <div role="button" class="{{btnClass}} uni-dropdown__button {{errorClass}}" {{action "buttonClick"}}>
     {{#if selected}}

--- a/addon/templates/components/uni-dropdown.hbs
+++ b/addon/templates/components/uni-dropdown.hbs
@@ -1,4 +1,4 @@
-{{#if isNativeOnMobile}}
+{{#if media.isMobile}}
   {{uni-select options=options useAlias=useAlias placeholder=placeholder}}
 {{else}}
   <div role="button" class="{{btnClass}} uni-dropdown__button {{errorClass}}" {{action "buttonClick"}}>

--- a/addon/templates/components/uni-dropdown.hbs
+++ b/addon/templates/components/uni-dropdown.hbs
@@ -1,27 +1,35 @@
-<div role="button" class="{{btnClass}} uni-dropdown__button {{errorClass}}" {{action "buttonClick"}}>
-  {{#if selected}}
-    {{#if selectedAlias}}
-      {{selectedAlias}}
-    {{else}}
-      {{selected}}
-    {{/if}}
-  {{else}}
-    {{placeholder}}
-  {{/if}}
-
-  {{#if selectedSvgs}}
-    <div class="uni-dropdown__svg-group">
-      {{#each selectedSvgs as |svg|}}
-        {{inline-svg svg}}
-      {{/each}}
-    </div>
-  {{/if}}
-</div>
-
-{{#if isOpen}}
-  <ul class="uni-dropdown__wrapper">
+{{#if isNativeOnMobile}}
+  <select class="{{btnClass}} uni-dropdown__button uni-dropdown__button--native-mobile {{errorClass}}" onchange={{action "optionClick" option=target.value}}>
     {{#each options as |option|}}
-      <li class="uni-dropdown__item" {{action "optionClick" option}}>{{yield option}}</li>
+      <option value="{{if option.value option.value option}}">{{yield option}}</option>
     {{/each}}
-  </ul>
+  </select>
+{{else}}
+  <div role="button" class="{{btnClass}} uni-dropdown__button {{errorClass}}" {{action "buttonClick"}}>
+    {{#if selected}}
+      {{#if selectedAlias}}
+        {{selectedAlias}}
+      {{else}}
+        {{selected}}
+      {{/if}}
+    {{else}}
+      {{placeholder}}
+    {{/if}}
+
+    {{#if selectedSvgs}}
+      <div class="uni-dropdown__svg-group">
+        {{#each selectedSvgs as |svg|}}
+          {{inline-svg svg}}
+        {{/each}}
+      </div>
+    {{/if}}
+  </div>
+
+  {{#if isOpen}}
+    <ul class="uni-dropdown__wrapper">
+      {{#each options as |option|}}
+        <li class="uni-dropdown__item" {{action "optionClick" option}}>{{yield option}}</li>
+      {{/each}}
+    </ul>
+  {{/if}}
 {{/if}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1499,7 +1499,7 @@
     "broccoli-config-loader": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/broccoli-config-loader/-/broccoli-config-loader-1.0.1.tgz",
-      "integrity": "sha1-0QqvjrwMtFwdpbqoJyDh2I0oyAo=",
+      "integrity": "sha512-MDKYQ50rxhn+g17DYdfzfEM9DjTuSGu42Db37A8TQHQe8geYEcUZ4SQqZRgzdAI3aRQNlA1yBHJfOeGmOjhLIg==",
       "dev": true,
       "requires": {
         "broccoli-caching-writer": "3.0.3"
@@ -1534,7 +1534,7 @@
     "broccoli-debug": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/broccoli-debug/-/broccoli-debug-0.6.3.tgz",
-      "integrity": "sha1-HzO7Dqy124E2bwSSUkyCsSF+tXg=",
+      "integrity": "sha512-YqpMH2QPHNtGoauVOj715dqDfurJa9O2and1UuxfzzGpM3A9mBrXeeLdWpTt8hj/Y8u8WaG/L1UBZYffPvTHVw==",
       "requires": {
         "broccoli-plugin": "1.3.0",
         "fs-tree-diff": "0.5.6",
@@ -2046,7 +2046,7 @@
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
     "clap": {
@@ -6838,7 +6838,7 @@
         "broccoli-babel-transpiler": {
           "version": "6.1.2",
           "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.1.2.tgz",
-          "integrity": "sha1-JgGcBFteo+RM/vYoITAvm9SDyr0=",
+          "integrity": "sha512-o1OUe5RZ5EP5+QICEmRNvWlhMvIciMisVACHu6qUPt6dE0Q0UnI5lUpWTmuXg/X+QuznqD/s1PApIpahv/QMZw==",
           "dev": true,
           "requires": {
             "babel-core": "6.25.0",
@@ -10818,7 +10818,7 @@
         "esprima": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-          "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ=",
+          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
           "dev": true
         }
       }
@@ -13241,7 +13241,7 @@
     "tap-parser": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-5.4.0.tgz",
-      "integrity": "sha1-aQfolyXXt/pq5B7ixGTD20MYiuw=",
+      "integrity": "sha512-BIsIaGqv7uTQgTW1KLTMNPSEQf4zDDPgYOBRdgOfuB+JFOLRBfEu6cLa/KvMvmqggu1FKXDfitjLwsq4827RvA==",
       "dev": true,
       "requires": {
         "events-to-array": "1.1.2",
@@ -13349,7 +13349,7 @@
     "tiny-lr": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-1.0.5.tgz",
-      "integrity": "sha1-IfQL+E69H4UwVmgDde7xZwwzQRI=",
+      "integrity": "sha512-YrxUSiMgOVh3PnAqtdAUQuUVEVRnqcRCxJ3BHrl/aaWV2fplKKB60oClM0GH2Gio2hcXvkxMUxsC/vXZrQePlg==",
       "dev": true,
       "requires": {
         "body": "5.1.0",


### PR DESCRIPTION
## JIRA Ticket

https://uniplaces.atlassian.net/browse/UN-11823

## Context

**TLDR: add on-demand native dropdown behaviour to uni-dropdown**

**Part 1 / 2** 
Implement behaviour on ember-cli-uniq to be used on SPA-Offer-Page's Full-edit mode Photo gallery.

The experience with calendars in mobile is not great, as they don't appear centered on the screen, and sometimes is not even possible to change months.
We need to fix this on the following calendars:

- Edit Blocked Period;
- Add New Blocked Period;

Also, we need to change the behaviour from the dropdown in the photo management (the units) to the native system.

## Screenshots

To be added.