### PR TITLE
[RFC][NI] Support dynamic options uni autocomplete

### DIFF
--- a/addon/components/uni-autocomplete.js
+++ b/addon/components/uni-autocomplete.js
@@ -40,7 +40,7 @@ export default Component.extend(ClickOutside, {
       }
 
       let options = this.get('options').map((option) => {
-        let matchedValues = this.get('filterFunction')(this.get('searchTextValues'), option);
+        let matchedValues = this.filterFunction(this.get('searchTextValues'), option);
 
         return { option, matchedValues };
       });

--- a/addon/components/uni-autocomplete.js
+++ b/addon/components/uni-autocomplete.js
@@ -15,7 +15,6 @@ export default Component.extend(ClickOutside, {
   value: '',
   showOptions: false,
   hasError: false,
-  disableFiltering: false,
   highlighted: 0,
   maxOptionsToShow: 4,
   autocomplete: 'off',
@@ -40,12 +39,8 @@ export default Component.extend(ClickOutside, {
         return [];
       }
 
-      if (this.get('disableFiltering')) {
-        return A(this.get('options').map((opt) => ({ option: opt, matchedValues: A(this.get('options')) })));
-      }
-
       let options = this.get('options').map((option) => {
-        let matchedValues = this.filterFunction(this.get('searchTextValues'), option);
+        let matchedValues = this.get('filterFunction')(this.get('searchTextValues'), option);
 
         return { option, matchedValues };
       });

--- a/addon/components/uni-autocomplete.js
+++ b/addon/components/uni-autocomplete.js
@@ -45,8 +45,7 @@ export default Component.extend(ClickOutside, {
       }
 
       let options = this.get('options').map((option) => {
-        let options = this.get('searchTextValues')(option).map((x) => x.toLowerCase());
-        let matchedValues = A(options.filter((el) => el.startsWith(this.get('valueLowerCase'))));
+        let matchedValues = this.filterFunction(this.get('searchTextValues'), option);
 
         return { option, matchedValues };
       });
@@ -119,6 +118,13 @@ export default Component.extend(ClickOutside, {
     return isEmpty(option)
       ? this.set('showOptions', false)
       : this.selectOption(option);
+  },
+
+  filterFunction(getSearchTextValues, option) {
+    let options = getSearchTextValues(option).map((x) => x.toLowerCase());
+    let matchedValues = A(options.filter((el) => el.startsWith(this.get('valueLowerCase'))));
+
+    return matchedValues;
   },
 
   _handleKeyPress(ev) {

--- a/addon/components/uni-autocomplete.js
+++ b/addon/components/uni-autocomplete.js
@@ -15,6 +15,7 @@ export default Component.extend(ClickOutside, {
   value: '',
   showOptions: false,
   hasError: false,
+  disableFiltering: false,
   highlighted: 0,
   maxOptionsToShow: 4,
   autocomplete: 'off',
@@ -33,10 +34,14 @@ export default Component.extend(ClickOutside, {
     return this.get('value').toLowerCase();
   }),
 
-  optionsFiltered: computed('value', {
+  optionsFiltered: computed('value', 'options', {
     get() {
       if (isBlank(this.get('value'))) {
         return [];
+      }
+
+      if (this.get('disableFiltering')) {
+        return A(this.get('options').map((opt) => ({ option: opt, matchedValues: A(this.get('options')) })));
       }
 
       let options = this.get('options').map((option) => {

--- a/tests/integration/components/uni-autocomplete-test.js
+++ b/tests/integration/components/uni-autocomplete-test.js
@@ -1,5 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { fillIn, keyEvent } from 'ember-native-dom-helpers';
+import { A } from '@ember/array';
 
 moduleForComponent('uni-autocomplete', 'Integration | Component | uni autocomplete', {
   integration: true
@@ -11,4 +13,61 @@ test('it renders', function(assert) {
   this.render(hbs`{{uni-autocomplete}}`);
 
   assert.equal(this.$().text().trim(), '');
+});
+
+test('it works with the default filter function', async function(assert) {
+  assert.expect(1);
+
+  this.setProperties({
+    searchTextValues: (option) => [option],
+    options: ['A', 'B', 'C', 'D'],
+    onSelected: () => {
+      assert.ok(true);
+    }
+  });
+
+  this.render(hbs`
+    {{#uni-autocomplete
+      options=options
+      searchTextValues=searchTextValues
+      onSelected=onSelected as |optionSearchable|}}
+      {{optionSearchable.option}}
+    {{/uni-autocomplete}}
+  `);
+
+  let letterAKeyCode = 65;
+
+  await fillIn('.uni-input', 'A');
+  await keyEvent('.uni-input', 'keydown', letterAKeyCode);
+});
+
+test('it works with a custom filter function', async function(assert) {
+  assert.expect(8);
+
+  this.setProperties({
+    searchTextValues: (option) => [option],
+    options: ['A', 'B', 'C', 'D'],
+    filterFunction: (getSearchTextValues, option) => {
+      assert.equal(typeof getSearchTextValues, 'function');
+      assert.ok(this.get('options').includes(option));
+
+      return A(['yo']);
+    },
+    onSelected: () => {}
+  });
+
+  this.render(hbs`
+    {{#uni-autocomplete
+      options=options
+      searchTextValues=searchTextValues
+      filterFunction=filterFunction
+      onSelected=onSelected as |optionSearchable|}}
+      {{optionSearchable.option}}
+    {{/uni-autocomplete}}
+  `);
+
+  let letterAKeyCode = 65;
+
+  await fillIn('.uni-input', 'A');
+  await keyEvent('.uni-input', 'keydown', letterAKeyCode);
 });


### PR DESCRIPTION
# Context
We wanted to use uni-autocomplete but with asynchronous data where `options` where always changing.

# What this does?
- Support dynamic options that can change and just show (and use the UI)
- Ability to disable the filtering (as it just filters if the options start with the same letters, we can have much improved search algorithms **as elastic search** and just pass what comes from the server as options)