### PR TITLE
[RFC][NI] Fix uni-modal deprecation warnings

### DIFF
--- a/addon/templates/components/uni-modal.hbs
+++ b/addon/templates/components/uni-modal.hbs
@@ -1,5 +1,5 @@
 {{#if isOpen}}
-  {{#modal-dialog close=(action "onCloseModal") renderInPlace=renderInPlace}}
+  {{#modal-dialog onClose=(action "onCloseModal") renderInPlace=renderInPlace}}
     <div class="{{baseCssClass}} {{modifierCssClass}}">
       <div class="{{baseCssClass}}__wrapper {{customCssComponentClass}}">
         {{#if title}}


### PR DESCRIPTION
Fix deprecation warning: 

> Specifying the close action for a modal-dialog component is no longer supported in favor of onClose