### PR TITLE
[WIP][NI] Add treeForPublic to exclude flags from build

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,29 @@
 /* eslint-env node */
 'use strict';
 
+const Funnel = require('broccoli-funnel');
+
 module.exports = {
-  name: 'ember-cli-uniq'
+  name: 'ember-cli-uniq',
+
+  included() {
+    this._super.included && this._super.included.apply(this, arguments);
+
+    let addonOptions = (this.parent && this.parent.options) || (this.app && this.app.options) || {};
+    let config = addonOptions[this.name] || {};
+
+    this.excludeFlags = config.excludeFlags;
+  },
+
+  treeForPublic() {
+    let tree = this._super.treeForPublic.apply(this, arguments);
+
+    if (this.excludeFlags) {
+      return new Funnel(tree, {
+        exclude: ['public/assets/images/flags']
+      });
+    }
+
+    return tree;
+  }
 };

--- a/index.js
+++ b/index.js
@@ -12,15 +12,17 @@ module.exports = {
     let addonOptions = (this.parent && this.parent.options) || (this.app && this.app.options) || {};
     let config = addonOptions[this.name] || {};
 
-    this.excludeFlags = config.excludeFlags;
+    this.excludeAssets = config.excludeAssets;
   },
 
   treeForPublic() {
     let tree = this._super.treeForPublic.apply(this, arguments);
 
-    if (this.excludeFlags) {
+    if (this.excludeAssets) {
       return new Funnel(tree, {
-        exclude: ['public/assets/images/flags']
+        exclude: this.excludeAssets.map((assetPath) => {
+          return `public/assets/${assetPath}`;
+        })
       });
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,100 +1,43 @@
 {
   "name": "ember-cli-uniq",
-  "version": "0.3.0",
+  "version": "0.2.14",
   "lockfileVersion": 1,
-  "requires": true,
   "dependencies": {
     "@ember/test-helpers": {
-      "version": "https://registry.npmjs.org/@ember/test-helpers/-/test-helpers-0.7.13.tgz",
-      "integrity": "sha512-bdvZPD7iP3wCY3Cfk2fZgfJpVTOywycURDbFJUXdmPtVIWUrioAPaYWjQhkUGyQs9laWBD1bgyMLtbhhqK890A==",
+      "version": "0.7.20",
+      "resolved": "https://registry.npmjs.org/@ember/test-helpers/-/test-helpers-0.7.20.tgz",
+      "integrity": "sha512-x0RWQwzPxUbF2RfDZyKCv6k2QZ/3UZgDgprb5JsLo1mBiUHg1JN0M+aFG6c8SZ4qdGacBMUMC7Sk/SIYpZ3u6g==",
       "dev": true,
-      "requires": {
-        "broccoli-funnel": "2.0.1",
-        "ember-cli-babel": "6.12.0",
-        "ember-cli-htmlbars-inline-precompile": "1.0.0"
-      },
       "dependencies": {
         "amd-name-resolver": {
           "version": "0.0.7",
           "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-0.0.7.tgz",
           "integrity": "sha1-gUMBrf6KLxCfboTV6TUZbvtmlhU=",
-          "dev": true,
-          "requires": {
-            "ensure-posix-path": "1.0.2"
-          }
+          "dev": true
         },
         "babel-plugin-ember-modules-api-polyfill": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.3.0.tgz",
           "integrity": "sha512-cv5ZimF5X52uW7Ul83UUxtsFZE6rZYkMv6qWnAeiDLT1/KtpVrTkJpwzDlvJ/FhKJZ43ih4GbFbhuhBKKT7vIw==",
-          "dev": true,
-          "requires": {
-            "ember-rfc176-data": "0.3.1"
-          }
+          "dev": true
         },
         "broccoli-funnel": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.1.tgz",
           "integrity": "sha512-C8Lnp9TVsSSiZMGEF16C0dCiNg2oJqUKwuZ1K4kVC6qRPG/2Cj/rtB5kRCC9qEbwqhX71bDbfHROx0L3J7zXQg==",
-          "dev": true,
-          "requires": {
-            "array-equal": "1.0.0",
-            "blank-object": "1.0.2",
-            "broccoli-plugin": "1.3.0",
-            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.7.tgz",
-            "heimdalljs": "0.2.5",
-            "minimatch": "3.0.4",
-            "mkdirp": "0.5.1",
-            "path-posix": "1.0.0",
-            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-            "symlink-or-copy": "1.1.8",
-            "walk-sync": "0.3.2"
-          }
+          "dev": true
         },
         "ember-cli-babel": {
           "version": "6.12.0",
           "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.12.0.tgz",
           "integrity": "sha512-LMwZ3Xf3Q3jQUXaJtLLJsbbhRZRNv/iea64lZ8OgqZp1fh66CSXfmqV3L9QSuYQKPDNqFiu2v6IpOT08C6GU6w==",
           "dev": true,
-          "requires": {
-            "amd-name-resolver": "0.0.7",
-            "babel-plugin-debug-macros": "0.1.11",
-            "babel-plugin-ember-modules-api-polyfill": "2.3.0",
-            "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-            "babel-polyfill": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
-            "babel-preset-env": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
-            "broccoli-babel-transpiler": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.1.2.tgz",
-            "broccoli-debug": "https://registry.npmjs.org/broccoli-debug/-/broccoli-debug-0.6.4.tgz",
-            "broccoli-funnel": "1.2.0",
-            "broccoli-source": "1.1.0",
-            "clone": "2.1.1",
-            "ember-cli-version-checker": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz",
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
-          },
           "dependencies": {
             "broccoli-funnel": {
               "version": "1.2.0",
               "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
               "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
-              "dev": true,
-              "requires": {
-                "array-equal": "1.0.0",
-                "blank-object": "1.0.2",
-                "broccoli-plugin": "1.3.0",
-                "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                "exists-sync": "0.0.4",
-                "fast-ordered-set": "1.0.3",
-                "fs-tree-diff": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.7.tgz",
-                "heimdalljs": "0.2.5",
-                "minimatch": "3.0.4",
-                "mkdirp": "0.5.1",
-                "path-posix": "1.0.0",
-                "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-                "symlink-or-copy": "1.1.8",
-                "walk-sync": "0.3.2"
-              }
+              "dev": true
             }
           }
         },
@@ -113,39 +56,32 @@
       "dev": true
     },
     "@glimmer/resolver": {
-      "version": "https://registry.npmjs.org/@glimmer/resolver/-/resolver-0.4.2.tgz",
-      "integrity": "sha512-OYOSn2qKPMWRTrInu4W7Ilx2q4+mFfeKS8o8SCWdGN6q/9LnRUvN3vfiAEEfpgoMSvEr8TSGw6/b2WSLWoYAAA==",
-      "dev": true,
-      "requires": {
-        "@glimmer/di": "0.2.0"
-      }
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@glimmer/resolver/-/resolver-0.4.3.tgz",
+      "integrity": "sha512-UhX6vlZbWRMq6pCquSC3wfWLM9kO0PhQPD1dZ3XnyZkmsvEE94Cq+EncA9JalUuevKoJrfUFRvrZ0xaz+yar3g==",
+      "dev": true
     },
     "abbrev": {
-      "version": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "accepts": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
-      "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
-      "dev": true,
-      "requires": {
-        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-        "negotiator": "0.6.1"
-      }
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+      "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+      "dev": true
     },
     "acorn": {
-      "version": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
-      "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug=="
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+      "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
     },
     "acorn-jsx": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
-      "requires": {
-        "acorn": "3.3.0"
-      },
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
@@ -161,31 +97,32 @@
       "integrity": "sha1-q11PuIP1loFtNRX495HAr0ht1ic=",
       "dev": true
     },
+    "ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "dev": true
+    },
+    "ajv-keywords": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+      "dev": true
+    },
     "align-text": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
-      }
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc="
     },
     "alter": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
-      "integrity": "sha1-x1iICGF1cgNKrmJICvJrHU0cs80=",
-      "requires": {
-        "stable": "0.1.6"
-      }
+      "integrity": "sha1-x1iICGF1cgNKrmJICvJrHU0cs80="
     },
     "amd-name-resolver": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-0.0.6.tgz",
-      "integrity": "sha1-0+S6Lfyqsdggwb6d6UfGeCjP5ZU=",
-      "requires": {
-        "ensure-posix-path": "1.0.2"
-      }
+      "integrity": "sha1-0+S6Lfyqsdggwb6d6UfGeCjP5ZU="
     },
     "amdefine": {
       "version": "1.0.1",
@@ -193,8 +130,9 @@
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "ansi-escapes": {
-      "version": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-      "integrity": "sha512-wiXutNjDUlNEDWHcYH3jtZUhd3c4/VojassD8zHdHCY13xbZy2XbW+NKQwA0tWGBVzDA9qEzYwfoSsWmviidhw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
       "dev": true
     },
     "ansi-regex": {
@@ -214,12 +152,169 @@
       "dev": true
     },
     "anymatch": {
-      "version": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+      "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
       "dev": true,
-      "requires": {
-        "micromatch": "2.3.11",
-        "normalize-path": "2.1.1"
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "braces": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.1.tgz",
+          "integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
+          "dev": true,
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true
+            }
+          }
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "dev": true,
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "dev": true
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "dev": true,
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true
+            }
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "dev": true,
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true
+            }
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "dev": true,
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true
+            }
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true
+            }
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true
+        }
       }
     },
     "aot-test-generators": {
@@ -227,9 +322,6 @@
       "resolved": "https://registry.npmjs.org/aot-test-generators/-/aot-test-generators-0.1.0.tgz",
       "integrity": "sha1-Q/D2Ffl8spjXkZwbC05rcxCwPNA=",
       "dev": true,
-      "requires": {
-        "jsesc": "2.5.1"
-      },
       "dependencies": {
         "jsesc": {
           "version": "2.5.1",
@@ -240,26 +332,20 @@
       }
     },
     "aproba": {
-      "version": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
     },
     "are-we-there-yet": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-      "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.3"
-      }
+      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0="
     },
     "argparse": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
-      "requires": {
-        "sprintf-js": "1.0.3"
-      },
       "dependencies": {
         "sprintf-js": {
           "version": "1.0.3",
@@ -273,10 +359,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "dev": true,
-      "requires": {
-        "arr-flatten": "1.1.0"
-      }
+      "dev": true
     },
     "arr-flatten": {
       "version": "1.1.0",
@@ -310,10 +393,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-to-error/-/array-to-error-1.1.1.tgz",
       "integrity": "sha1-1ogSkm0UCXogVXmmZ+6vGFakTAc=",
-      "dev": true,
-      "requires": {
-        "array-to-sentence": "1.1.0"
-      }
+      "dev": true
     },
     "array-to-sentence": {
       "version": "1.1.0",
@@ -325,10 +405,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true,
-      "requires": {
-        "array-uniq": "1.0.3"
-      }
+      "dev": true
     },
     "array-uniq": {
       "version": "1.0.3",
@@ -381,24 +458,14 @@
       "integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk="
     },
     "async": {
-      "version": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-      "requires": {
-        "lodash": "4.17.4"
-      }
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw=="
     },
     "async-disk-cache": {
-      "version": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.3.3.tgz",
-      "integrity": "sha512-GyaWSbDAZCltxSobtj1m1ptXa0+zSdjWs3sM4IqnvhoRwMDHW5786sXQ1RiXbR3ZGuQe6NXMB4N0vUmW163cew==",
-      "requires": {
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-        "heimdalljs": "0.2.5",
-        "istextorbinary": "2.1.0",
-        "mkdirp": "0.5.1",
-        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-        "rsvp": "3.6.2",
-        "username-sync": "1.0.1"
-      }
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.3.3.tgz",
+      "integrity": "sha512-GyaWSbDAZCltxSobtj1m1ptXa0+zSdjWs3sM4IqnvhoRwMDHW5786sXQ1RiXbR3ZGuQe6NXMB4N0vUmW163cew=="
     },
     "async-each": {
       "version": "1.0.1",
@@ -412,12 +479,9 @@
       "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI="
     },
     "async-promise-queue": {
-      "version": "https://registry.npmjs.org/async-promise-queue/-/async-promise-queue-1.0.4.tgz",
-      "integrity": "sha512-GQ5X3DT+TefYuFPHdvIPXFTlKnh39U7dwtl+aUBGeKjMea9nBpv3c91DXgeyBQmY07vQ97f3Sr9XHqkamEameQ==",
-      "requires": {
-        "async": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
-      }
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/async-promise-queue/-/async-promise-queue-1.0.4.tgz",
+      "integrity": "sha512-GQ5X3DT+TefYuFPHdvIPXFTlKnh39U7dwtl+aUBGeKjMea9nBpv3c91DXgeyBQmY07vQ97f3Sr9XHqkamEameQ=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -425,9 +489,9 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.0.3.tgz",
-      "integrity": "sha1-GcenYEc3dEaPILLS0DNyrX1Mv10=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.0.tgz",
+      "integrity": "sha512-SuiKH8vbsOyCALjA/+EINmt/Kdl+TQPrtFgW7XZZcwtryFu9e5kQoX3bjCW6mIvGH1fbeAZZuvwGR5IlBRznGw==",
       "dev": true
     },
     "aws-sign2": {
@@ -441,52 +505,19 @@
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
     },
     "babel-code-frame": {
-      "version": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha512-XqYMR2dfdGMW+hd0IUZ2PwK+fGeFkOxZJ0wY+JaQAHzt1Zx8LcvpiZD2NiGkEG8qx0CfkAOr5xt76d1e8vG90g==",
-      "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
-      }
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s="
     },
     "babel-core": {
-      "version": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
-      "integrity": "sha512-FSiqfr4SYrH5Zv5KgWahyY99VC+Aod1ioMRNvL1lPS4WTUqvPAdYo7ioWEhDHEDqZADapbJZMX0sBuRsc93bDQ==",
-      "requires": {
-        "babel-code-frame": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-        "babel-generator": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-        "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-        "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-        "json5": "0.5.1",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4",
-        "path-is-absolute": "1.0.1",
-        "private": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-        "slash": "1.0.0",
-        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
-      }
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
+      "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g="
     },
     "babel-generator": {
-      "version": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
-      "integrity": "sha512-9SxJ4+NI4HBbS3U5wtiY+Fd/XRH8D4WHeeQVwViYijL73U1jXQHjxmn9aOiD+/orbvw7YgakoyO3eejaE3Gk2Q==",
-      "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.4",
-        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-        "trim-right": "1.0.1"
-      },
+      "version": "6.26.1",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+      "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
       "dependencies": {
         "jsesc": {
           "version": "1.3.0",
@@ -498,141 +529,72 @@
     "babel-helper-builder-binary-assignment-operator-visitor": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
-      "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-      "requires": {
-        "babel-helper-explode-assignable-expression": "6.24.1",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz"
-      }
+      "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ="
     },
     "babel-helper-call-delegate": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
-      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-      "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz"
-      }
+      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340="
     },
     "babel-helper-define-map": {
-      "version": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
-      "integrity": "sha512-bHkmjcC9lM1kmZcVpA5t2om2nzT/xiZpo6TJq7UlZ3wqKfzia4veeXbIhKvJXAMzhhEBd3cR1IElL5AenWEUpA==",
-      "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-        "lodash": "4.17.4"
-      }
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
+      "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8="
     },
     "babel-helper-explode-assignable-expression": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
-      "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz"
-      }
+      "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo="
     },
     "babel-helper-function-name": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-      "requires": {
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz"
-      }
+      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk="
     },
     "babel-helper-get-function-arity": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz"
-      }
+      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0="
     },
     "babel-helper-hoist-variables": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
-      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz"
-      }
+      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY="
     },
     "babel-helper-optimise-call-expression": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
-      "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz"
-      }
+      "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc="
     },
     "babel-helper-regex": {
-      "version": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
-      "integrity": "sha512-VlPiWmqmGJp0x0oK27Out1D+71nVVCTSdlbhIVoaBAj2lUgrNjBCRR9+llO4lTSb2O4r7PJg+RobRkhBrf6ofg==",
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-        "lodash": "4.17.4"
-      }
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
+      "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI="
     },
     "babel-helper-remap-async-to-generator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
-      "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-      "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz"
-      }
+      "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs="
     },
     "babel-helper-replace-supers": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
-      "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
-      "requires": {
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz"
-      }
+      "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo="
     },
     "babel-helpers": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
-      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz"
-      }
+      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI="
     },
     "babel-messages": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz"
-      }
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4="
     },
     "babel-plugin-check-es2015-constants": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
-      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz"
-      }
+      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o="
     },
     "babel-plugin-constant-folding": {
       "version": "1.0.1",
@@ -647,17 +609,12 @@
     "babel-plugin-debug-macros": {
       "version": "0.1.11",
       "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.1.11.tgz",
-      "integrity": "sha512-hZw5qNNGAR02Y+yBUrtsnJHh8OXavkayPRqKGAXnIm4t5rWVpj3ArwsC7TWdpZsBguQvHAeyTxZ7s23yY60HHg==",
-      "requires": {
-        "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
-      }
+      "integrity": "sha512-hZw5qNNGAR02Y+yBUrtsnJHh8OXavkayPRqKGAXnIm4t5rWVpj3ArwsC7TWdpZsBguQvHAeyTxZ7s23yY60HHg=="
     },
     "babel-plugin-ember-modules-api-polyfill": {
-      "version": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-1.6.0.tgz",
-      "integrity": "sha512-HIOU4QBiselFqEvx6QaKrS/zxnfRQygQyA8wGdVUd42zO26G0jUqbEr1IE/NkTAbP4zsF0sY/ZLtVpjYiVB3VQ==",
-      "requires": {
-        "ember-rfc176-data": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.2.7.tgz"
-      }
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-1.6.0.tgz",
+      "integrity": "sha512-HIOU4QBiselFqEvx6QaKrS/zxnfRQygQyA8wGdVUd42zO26G0jUqbEr1IE/NkTAbP4zsF0sY/ZLtVpjYiVB3VQ=="
     },
     "babel-plugin-eval": {
       "version": "1.0.1",
@@ -665,9 +622,9 @@
       "integrity": "sha1-ovrtJc5r5preS/7CY/cBaRlZUNo="
     },
     "babel-plugin-htmlbars-inline-precompile": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-0.2.3.tgz",
-      "integrity": "sha1-zTZeJ4r0Cb+mvncExDVL7udCRGs=",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-0.2.4.tgz",
+      "integrity": "sha1-VLSBaEMrvAPx8m8ukJDLIivHjHU=",
       "dev": true
     },
     "babel-plugin-inline-environment-variables": {
@@ -694,9 +651,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz",
       "integrity": "sha1-xJ56/QL1d7xNoF6i3wAiUM980SM=",
-      "requires": {
-        "lodash": "3.10.1"
-      },
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
@@ -748,256 +702,137 @@
     "babel-plugin-transform-async-to-generator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
-      "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-      "requires": {
-        "babel-helper-remap-async-to-generator": "6.24.1",
-        "babel-plugin-syntax-async-functions": "6.13.0",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz"
-      }
+      "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E="
     },
     "babel-plugin-transform-es2015-arrow-functions": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
-      "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz"
-      }
+      "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE="
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
-      "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz"
-      }
+      "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE="
     },
     "babel-plugin-transform-es2015-block-scoping": {
-      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
-      "integrity": "sha512-YiN6sFAQ5lML8JjCmr7uerS5Yc/EMbgg9G8ZNmk2E3nYX4ckHR01wrkeeMijEf5WHNK5TW0Sl0Uu3pv3EdOJWw==",
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-        "lodash": "4.17.4"
-      }
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+      "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8="
     },
     "babel-plugin-transform-es2015-classes": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
-      "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
-      "requires": {
-        "babel-helper-define-map": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
-        "babel-helper-function-name": "6.24.1",
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz"
-      }
+      "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs="
     },
     "babel-plugin-transform-es2015-computed-properties": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
-      "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz"
-      }
+      "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM="
     },
     "babel-plugin-transform-es2015-destructuring": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
-      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz"
-      }
+      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0="
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
-      "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz"
-      }
+      "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4="
     },
     "babel-plugin-transform-es2015-for-of": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
-      "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz"
-      }
+      "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE="
     },
     "babel-plugin-transform-es2015-function-name": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
-      "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-      "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz"
-      }
+      "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos="
     },
     "babel-plugin-transform-es2015-literals": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
-      "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz"
-      }
+      "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4="
     },
     "babel-plugin-transform-es2015-modules-amd": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
-      "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
-      "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz"
-      }
+      "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ="
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
-      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
-      "integrity": "sha512-t33zrLpy4zDVZ/MnEk5GK4j4VAbEeLgKXM89RZPqSuRpuoZCqdxN8OgePBHKR7eBM9IyW5oCLL0xbw6H7I/qaw==",
-      "requires": {
-        "babel-plugin-transform-strict-mode": "6.24.1",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz"
-      }
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
+      "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo="
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
-      "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
-      "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz"
-      }
+      "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM="
     },
     "babel-plugin-transform-es2015-modules-umd": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
-      "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
-      "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz"
-      }
+      "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg="
     },
     "babel-plugin-transform-es2015-object-super": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
-      "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-      "requires": {
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz"
-      }
+      "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40="
     },
     "babel-plugin-transform-es2015-parameters": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
-      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-      "requires": {
-        "babel-helper-call-delegate": "6.24.1",
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz"
-      }
+      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys="
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
-      "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz"
-      }
+      "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA="
     },
     "babel-plugin-transform-es2015-spread": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
-      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz"
-      }
+      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE="
     },
     "babel-plugin-transform-es2015-sticky-regex": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
-      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-      "requires": {
-        "babel-helper-regex": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz"
-      }
+      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw="
     },
     "babel-plugin-transform-es2015-template-literals": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
-      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz"
-      }
+      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0="
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
-      "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz"
-      }
+      "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I="
     },
     "babel-plugin-transform-es2015-unicode-regex": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
-      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-      "requires": {
-        "babel-helper-regex": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-        "regexpu-core": "2.0.0"
-      }
+      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek="
     },
     "babel-plugin-transform-exponentiation-operator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
-      "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-      "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz"
-      }
+      "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4="
     },
     "babel-plugin-transform-regenerator": {
-      "version": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
-      "integrity": "sha512-LS+dBkUGlNR15/5WHKe/8Neawx663qttS6AGqoOUhICc9d1KciBvtrQSuc0PI+CxQ2Q/S1aKuJ+u64GtLdcEZg==",
-      "requires": {
-        "regenerator-transform": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz"
-      }
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
+      "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8="
     },
     "babel-plugin-transform-strict-mode": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
-      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz"
-      }
+      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g="
     },
     "babel-plugin-undeclared-variables-check": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
-      "integrity": "sha1-XPGqU52BP/ZOmWQSkK9iCWX2Xe4=",
-      "requires": {
-        "leven": "1.0.2"
-      }
+      "integrity": "sha1-XPGqU52BP/ZOmWQSkK9iCWX2Xe4="
     },
     "babel-plugin-undefined-to-void": {
       "version": "1.1.6",
@@ -1005,13 +840,9 @@
       "integrity": "sha1-f1eO+LeN+uYAM4XYQXph7aBuL4E="
     },
     "babel-polyfill": {
-      "version": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
-      "integrity": "sha512-F2rZGQnAdaHWQ8YAoeRbukc7HS9QgdgeyJ0rQDd485v9opwuPvjpPFcOOT/WmkKTdgy9ESgSPXDcTNpzrGr6iQ==",
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-        "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-        "regenerator-runtime": "0.10.5"
-      },
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
       "dependencies": {
         "regenerator-runtime": {
           "version": "0.10.5",
@@ -1021,110 +852,45 @@
       }
     },
     "babel-preset-env": {
-      "version": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
-      "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
-      "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-        "babel-plugin-transform-async-to-generator": "6.24.1",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
-        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "6.24.1",
-        "babel-plugin-transform-regenerator": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
-        "browserslist": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
-        "invariant": "2.2.2",
-        "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
-      }
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
+      "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA=="
     },
     "babel-register": {
-      "version": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
-      "integrity": "sha512-veliHlHX06wjaeY8xNITbveXSiI+ASFnOqvne/LaIJIqOWi2Ogmj91KOugEz/hoh/fwMhXNBJPCv8Xaz5CyM4A==",
-      "requires": {
-        "babel-core": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-        "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-        "home-or-tmp": "2.0.0",
-        "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
-        "source-map-support": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz"
-      }
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+      "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE="
     },
     "babel-runtime": {
-      "version": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
-      "requires": {
-        "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-        "regenerator-runtime": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz"
-      }
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4="
     },
     "babel-template": {
-      "version": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-      "integrity": "sha512-PCOcLFW7/eazGUKIoqH97sO9A2UYMahsn/yRQ7uOk37iutwjq7ODtcTNF+iFDSHNfkctqsLRjLP7URnOx0T1fg==",
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-        "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-        "lodash": "4.17.4"
-      }
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI="
     },
     "babel-traverse": {
-      "version": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-      "integrity": "sha512-iSxeXx7apsjCHe9c7n8VtRXGzI2Bk1rBSOJgCCjfyXb6v1aCqE1KSEpq/8SXuVN8Ka/Rh1WDTF0MDzkvTA4MIA==",
-      "requires": {
-        "babel-code-frame": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-        "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-        "globals": "9.18.0",
-        "invariant": "2.2.2",
-        "lodash": "4.17.4"
-      }
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4="
     },
     "babel-types": {
-      "version": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-      "integrity": "sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==",
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-        "esutils": "2.0.2",
-        "lodash": "4.17.4",
-        "to-fast-properties": "1.0.3"
-      }
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc="
     },
     "babylon": {
-      "version": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
       "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
     },
     "backbone": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.3.3.tgz",
       "integrity": "sha1-TMgOp8sWMaxHSInOQPL4vGg7KZk=",
-      "dev": true,
-      "requires": {
-        "underscore": "1.8.3"
-      }
+      "dev": true
     },
     "backo2": {
       "version": "1.0.2",
@@ -1142,30 +908,12 @@
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
-      "requires": {
-        "cache-base": "1.0.1",
-        "class-utils": "0.3.6",
-        "component-emitter": "1.2.1",
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "mixin-deep": "1.3.1",
-        "pascalcase": "0.1.1"
-      },
       "dependencies": {
-        "component-emitter": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-          "dev": true
-        },
         "define-property": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-          "dev": true,
-          "requires": {
-            "is-descriptor": "1.0.2"
-          }
+          "dev": true
         },
         "isobject": {
           "version": "3.0.1",
@@ -1191,38 +939,30 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.0.tgz",
       "integrity": "sha1-AV2z81PgLlY3d1X5YnQuiYHnu7o=",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
+      "dev": true
     },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "optional": true,
-      "requires": {
-        "tweetnacl": "0.14.5"
-      }
+      "optional": true
     },
     "better-assert": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
       "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
-      "dev": true,
-      "requires": {
-        "callsite": "1.0.0"
-      }
+      "dev": true
     },
     "binary-extensions": {
-      "version": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
-      "integrity": "sha512-9XXbu17rAPSov41Lvd1NwrwA3Wvh2WRpxJptRjVTw55R+ZIQ9QrzuEPMMPhxXry2GTpmmUXwd8rSvp50H+7uQA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
+      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
       "dev": true
     },
     "binaryextensions": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.0.0.tgz",
-      "integrity": "sha1-5ZfRp6ajVYotHHJBoWyZll5qpA8="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.1.1.tgz",
+      "integrity": "sha512-XBaoWE9RW8pPdPQNibZsW2zh8TW6gcarXp1FZPwT8Uop8ScSNldJEWf2k9l3HeTqdrEwsOsFcq74RiJECW34yA=="
     },
     "blank-object": {
       "version": "1.0.2",
@@ -1238,10 +978,7 @@
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-      "requires": {
-        "inherits": "2.0.3"
-      }
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo="
     },
     "bluebird": {
       "version": "2.11.0",
@@ -1253,12 +990,6 @@
       "resolved": "https://registry.npmjs.org/body/-/body-5.1.0.tgz",
       "integrity": "sha1-5LoM5BCkaTYyM2dgnstOZVMSUGk=",
       "dev": true,
-      "requires": {
-        "continuable-cache": "0.3.1",
-        "error": "7.0.2",
-        "raw-body": "1.1.7",
-        "safe-json-parse": "1.0.1"
-      },
       "dependencies": {
         "bytes": {
           "version": "1.0.0",
@@ -1270,11 +1001,7 @@
           "version": "1.1.7",
           "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz",
           "integrity": "sha1-HQJ8K/oRasxmI7yo8AAWVyqH1CU=",
-          "dev": true,
-          "requires": {
-            "bytes": "1.0.0",
-            "string_decoder": "0.10.31"
-          }
+          "dev": true
         },
         "string_decoder": {
           "version": "0.10.31",
@@ -1289,18 +1016,6 @@
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
       "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
       "dev": true,
-      "requires": {
-        "bytes": "3.0.0",
-        "content-type": "1.0.4",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-        "depd": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-        "http-errors": "1.6.2",
-        "iconv-lite": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-        "on-finished": "2.3.0",
-        "qs": "6.5.1",
-        "raw-body": "2.3.2",
-        "type-is": "1.6.15"
-      },
       "dependencies": {
         "qs": {
           "version": "6.5.1",
@@ -1313,23 +1028,13 @@
     "boom": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "requires": {
-        "hoek": "2.16.3"
-      }
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8="
     },
     "bower-config": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-1.4.1.tgz",
       "integrity": "sha1-hf2d82fCuNu9DKpMXyutQM2Ewsw=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "mout": "1.1.0",
-        "optimist": "0.6.1",
-        "osenv": "0.1.4",
-        "untildify": "2.1.0"
-      }
+      "dev": true
     },
     "bower-endpoint-parser": {
       "version": "0.2.2",
@@ -1338,24 +1043,15 @@
       "dev": true
     },
     "brace-expansion": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "requires": {
-        "balanced-match": "1.0.0",
-        "concat-map": "0.0.1"
-      }
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA=="
     },
     "braces": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-      "dev": true,
-      "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
-      }
+      "dev": true
     },
     "breakable": {
       "version": "1.0.0",
@@ -1363,119 +1059,56 @@
       "integrity": "sha1-eEp5eRWjjq0nutRWtVcstLuqeME="
     },
     "broccoli-asset-rev": {
-      "version": "https://registry.npmjs.org/broccoli-asset-rev/-/broccoli-asset-rev-2.6.0.tgz",
-      "integrity": "sha512-t/RJsSvjNyxlACPdnigLIDTv2wBDTQ1ABHzuvDVk4B8Refi9/82kgm9M27ez4yiPiv4cXBeeL4MyN1JOlaRJUg==",
-      "dev": true,
-      "requires": {
-        "broccoli-asset-rewrite": "1.1.0",
-        "broccoli-filter": "1.2.4",
-        "json-stable-stringify": "1.0.1",
-        "minimatch": "3.0.4",
-        "rsvp": "3.6.2"
-      }
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/broccoli-asset-rev/-/broccoli-asset-rev-2.7.0.tgz",
+      "integrity": "sha512-GZ7gU3Qo6HMAUqDeh1q+4UVCQPJPjCyGcpIY5s9Qp58a244FT4nZSiy8qYkVC4LLIWTZt59G7jFFsUcj/13IPQ==",
+      "dev": true
     },
     "broccoli-asset-rewrite": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/broccoli-asset-rewrite/-/broccoli-asset-rewrite-1.1.0.tgz",
       "integrity": "sha1-d6XaVhV6oxjFkRMkXouvtGF/iDA=",
-      "dev": true,
-      "requires": {
-        "broccoli-filter": "1.2.4"
-      }
+      "dev": true
     },
     "broccoli-babel-transpiler": {
-      "version": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.1.2.tgz",
-      "integrity": "sha512-o1OUe5RZ5EP5+QICEmRNvWlhMvIciMisVACHu6qUPt6dE0Q0UnI5lUpWTmuXg/X+QuznqD/s1PApIpahv/QMZw==",
-      "requires": {
-        "babel-core": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
-        "broccoli-funnel": "1.2.0",
-        "broccoli-merge-trees": "1.2.4",
-        "broccoli-persistent-filter": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
-        "clone": "2.1.1",
-        "hash-for-dep": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
-        "heimdalljs-logger": "0.1.9",
-        "json-stable-stringify": "1.0.1",
-        "rsvp": "3.6.2",
-        "workerpool": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.0.tgz"
-      }
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.1.4.tgz",
+      "integrity": "sha512-h63g7iOBWdxj0GuZw8kNsyaD1T9weKsY3I+gp3rOefozbHwUesJ43vzLy0jj3t/rbiP2czcJAlyHS48EcRil8Q=="
     },
     "broccoli-brocfile-loader": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/broccoli-brocfile-loader/-/broccoli-brocfile-loader-0.18.0.tgz",
       "integrity": "sha1-LoYCHIBcNP/I0povtyHPJz6Bnks=",
-      "dev": true,
-      "requires": {
-        "findup-sync": "0.4.3"
-      }
+      "dev": true
     },
     "broccoli-builder": {
-      "version": "https://registry.npmjs.org/broccoli-builder/-/broccoli-builder-0.18.11.tgz",
+      "version": "0.18.11",
+      "resolved": "https://registry.npmjs.org/broccoli-builder/-/broccoli-builder-0.18.11.tgz",
       "integrity": "sha512-4Qa3uTev+adLRTEv2zO1M5dXSFCgywo8bCMxJ8vmas8q+dAIstc1eKnnymJgpejyuEJQAjgdhO1zxMQCrt03Ew==",
-      "dev": true,
-      "requires": {
-        "heimdalljs": "0.2.5",
-        "promise-map-series": "0.2.3",
-        "quick-temp": "0.1.8",
-        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-        "rsvp": "3.6.2",
-        "silent-error": "1.1.0"
-      }
+      "dev": true
     },
     "broccoli-caching-writer": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/broccoli-caching-writer/-/broccoli-caching-writer-3.0.3.tgz",
-      "integrity": "sha1-C9LJapc41qarWQ8HujXFFX19tHY=",
-      "requires": {
-        "broccoli-kitchen-sink-helpers": "0.3.1",
-        "broccoli-plugin": "1.3.0",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-        "rsvp": "3.6.2",
-        "walk-sync": "0.3.2"
-      }
+      "integrity": "sha1-C9LJapc41qarWQ8HujXFFX19tHY="
     },
     "broccoli-clean-css": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/broccoli-clean-css/-/broccoli-clean-css-1.1.0.tgz",
       "integrity": "sha1-nbFD2a9+CuecJuOsWpuy1yDqGfo=",
-      "dev": true,
-      "requires": {
-        "broccoli-persistent-filter": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
-        "clean-css-promise": "0.1.1",
-        "inline-source-map-comment": "1.0.5",
-        "json-stable-stringify": "1.0.1"
-      }
+      "dev": true
     },
     "broccoli-concat": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/broccoli-concat/-/broccoli-concat-3.2.2.tgz",
       "integrity": "sha1-hv/cUmButZC6n2uJTF7HoBb1t7k=",
       "dev": true,
-      "requires": {
-        "broccoli-kitchen-sink-helpers": "0.3.1",
-        "broccoli-plugin": "1.3.0",
-        "broccoli-stew": "1.5.0",
-        "ensure-posix-path": "1.0.2",
-        "fast-sourcemap-concat": "https://registry.npmjs.org/fast-sourcemap-concat/-/fast-sourcemap-concat-1.2.3.tgz",
-        "find-index": "1.1.0",
-        "fs-extra": "1.0.0",
-        "fs-tree-diff": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.7.tgz",
-        "lodash.merge": "4.6.0",
-        "lodash.omit": "4.5.0",
-        "lodash.uniq": "4.5.0",
-        "walk-sync": "0.3.2"
-      },
       "dependencies": {
         "fs-extra": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
           "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.1"
-          }
+          "dev": true
         }
       }
     },
@@ -1483,84 +1116,44 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/broccoli-config-loader/-/broccoli-config-loader-1.0.1.tgz",
       "integrity": "sha512-MDKYQ50rxhn+g17DYdfzfEM9DjTuSGu42Db37A8TQHQe8geYEcUZ4SQqZRgzdAI3aRQNlA1yBHJfOeGmOjhLIg==",
-      "dev": true,
-      "requires": {
-        "broccoli-caching-writer": "3.0.3"
-      }
+      "dev": true
     },
     "broccoli-config-replace": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/broccoli-config-replace/-/broccoli-config-replace-1.1.2.tgz",
       "integrity": "sha1-bqh52SpbrWNNETKbUfxfSq/anAA=",
       "dev": true,
-      "requires": {
-        "broccoli-kitchen-sink-helpers": "0.3.1",
-        "broccoli-plugin": "1.3.0",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-        "fs-extra": "0.24.0"
-      },
       "dependencies": {
         "fs-extra": {
           "version": "0.24.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.24.0.tgz",
           "integrity": "sha1-1OQ0KpZnXLeEZjOmCZJJMytTmVI=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "path-is-absolute": "1.0.1",
-            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz"
-          }
+          "dev": true
         }
       }
     },
     "broccoli-debug": {
-      "version": "https://registry.npmjs.org/broccoli-debug/-/broccoli-debug-0.6.4.tgz",
-      "integrity": "sha512-CixMUndBqTljCc26i6ubhBrGbAWXpWBsGJFce6ZOr76Tul2Ev1xxM0tmf7OjSzdYhkr5BrPd/CNbR9VMPi+NBg==",
-      "requires": {
-        "broccoli-plugin": "1.3.0",
-        "fs-tree-diff": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.7.tgz",
-        "heimdalljs": "0.2.5",
-        "heimdalljs-logger": "0.1.9",
-        "symlink-or-copy": "1.1.8",
-        "tree-sync": "1.2.2"
-      }
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/broccoli-debug/-/broccoli-debug-0.6.4.tgz",
+      "integrity": "sha512-CixMUndBqTljCc26i6ubhBrGbAWXpWBsGJFce6ZOr76Tul2Ev1xxM0tmf7OjSzdYhkr5BrPd/CNbR9VMPi+NBg=="
     },
     "broccoli-file-creator": {
-      "version": "https://registry.npmjs.org/broccoli-file-creator/-/broccoli-file-creator-1.1.1.tgz",
-      "integrity": "sha512-lHEQOqnpEyDK4c6BafLzySH3oC5gV+AgQFcjpETHelVmPDFB4mktphj2quFPcIQRXmVA+pVNA5BskG4HArguoQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/broccoli-file-creator/-/broccoli-file-creator-1.1.1.tgz",
+      "integrity": "sha1-GzW2fSFavfrdjUnutpSTw55sNFA=",
       "dev": true,
-      "requires": {
-        "broccoli-kitchen-sink-helpers": "0.2.9",
-        "broccoli-plugin": "1.3.0",
-        "broccoli-writer": "0.1.1",
-        "mkdirp": "0.5.1",
-        "rsvp": "3.0.21",
-        "symlink-or-copy": "1.1.8"
-      },
       "dependencies": {
         "broccoli-kitchen-sink-helpers": {
           "version": "0.2.9",
           "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
           "integrity": "sha1-peCYbtjXb7WYS2jD8EUNOpbjbsw=",
-          "dev": true,
-          "requires": {
-            "glob": "5.0.15",
-            "mkdirp": "0.5.1"
-          }
+          "dev": true
         },
         "glob": {
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true,
-          "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+          "dev": true
         },
         "rsvp": {
           "version": "3.0.21",
@@ -1571,52 +1164,28 @@
       }
     },
     "broccoli-filter": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/broccoli-filter/-/broccoli-filter-1.2.4.tgz",
-      "integrity": "sha1-QJr7lLmjptqfrIE06R4gX0DMczA=",
-      "dev": true,
-      "requires": {
-        "broccoli-kitchen-sink-helpers": "0.3.1",
-        "broccoli-plugin": "1.3.0",
-        "copy-dereference": "1.0.0",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-        "mkdirp": "0.5.1",
-        "promise-map-series": "0.2.3",
-        "rsvp": "3.6.2",
-        "symlink-or-copy": "1.1.8",
-        "walk-sync": "0.3.2"
-      }
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/broccoli-filter/-/broccoli-filter-1.3.0.tgz",
+      "integrity": "sha512-VXJXw7eBfG82CFxaBDjYmyN7V72D4In2zwLVQJd/h3mBfF3CMdRTsv2L20lmRTtCv1sAHcB+LgMso90e/KYiLw==",
+      "dev": true
     },
     "broccoli-flatiron": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/broccoli-flatiron/-/broccoli-flatiron-0.0.0.tgz",
       "integrity": "sha1-6XUEAWtW7qBIE7XYYv2hi28Rp38=",
       "dev": true,
-      "requires": {
-        "broccoli-kitchen-sink-helpers": "0.2.9",
-        "broccoli-writer": "0.1.1",
-        "mkdirp": "0.3.5",
-        "rsvp": "3.0.21"
-      },
       "dependencies": {
         "broccoli-kitchen-sink-helpers": {
           "version": "0.2.9",
           "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
           "integrity": "sha1-peCYbtjXb7WYS2jD8EUNOpbjbsw=",
           "dev": true,
-          "requires": {
-            "glob": "5.0.15",
-            "mkdirp": "0.5.1"
-          },
           "dependencies": {
             "mkdirp": {
               "version": "0.5.1",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-              "dev": true,
-              "requires": {
-                "minimist": "0.0.8"
-              }
+              "dev": true
             }
           }
         },
@@ -1624,14 +1193,7 @@
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true,
-          "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+          "dev": true
         },
         "mkdirp": {
           "version": "0.3.5",
@@ -1650,23 +1212,7 @@
     "broccoli-funnel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
-      "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
-      "requires": {
-        "array-equal": "1.0.0",
-        "blank-object": "1.0.2",
-        "broccoli-plugin": "1.3.0",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-        "exists-sync": "0.0.4",
-        "fast-ordered-set": "1.0.3",
-        "fs-tree-diff": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.7.tgz",
-        "heimdalljs": "0.2.5",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "path-posix": "1.0.0",
-        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-        "symlink-or-copy": "1.1.8",
-        "walk-sync": "0.3.2"
-      }
+      "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY="
     },
     "broccoli-funnel-reducer": {
       "version": "1.0.0",
@@ -1678,91 +1224,45 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.3.1.tgz",
       "integrity": "sha1-d8fBgZS5ZkFj7E/O4nk0RJJuDAY=",
-      "requires": {
-        "glob": "5.0.15",
-        "mkdirp": "0.5.1"
-      },
       "dependencies": {
         "glob": {
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E="
         }
       }
+    },
+    "broccoli-lint-eslint": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/broccoli-lint-eslint/-/broccoli-lint-eslint-4.2.1.tgz",
+      "integrity": "sha512-Jvm06UvuMPa5gEH+9/Sb+QpoIodDAYzbyIUEqxniPCdA6JJooa91hQDCTJc32RUV46JNMcLhb3Dl55BdA8v5mw==",
+      "dev": true
     },
     "broccoli-merge-trees": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz",
-      "integrity": "sha1-oAFRm7UGfwZYnZGvopQkRaLQ/bU=",
-      "requires": {
-        "broccoli-plugin": "1.3.0",
-        "can-symlink": "1.0.0",
-        "fast-ordered-set": "1.0.3",
-        "fs-tree-diff": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.7.tgz",
-        "heimdalljs": "0.2.5",
-        "heimdalljs-logger": "0.1.9",
-        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-        "symlink-or-copy": "1.1.8"
-      }
+      "integrity": "sha1-oAFRm7UGfwZYnZGvopQkRaLQ/bU="
     },
     "broccoli-middleware": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/broccoli-middleware/-/broccoli-middleware-1.0.0.tgz",
-      "integrity": "sha1-kvTh+5p5HqmGJFpwd/NcxkjasJc=",
-      "dev": true,
-      "requires": {
-        "handlebars": "4.0.11",
-        "mime": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz"
-      }
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/broccoli-middleware/-/broccoli-middleware-1.2.1.tgz",
+      "integrity": "sha1-oh8lX4v+WiHC8PvyQXrd2dJMlDY=",
+      "dev": true
     },
     "broccoli-persistent-filter": {
-      "version": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
-      "integrity": "sha512-JwNLDvvXJlhUmr+CHcbVhCyp33NbCIAITjQZmJY9e8QzANXh3jpFWlhSFvkWghwKA8rTAKcXkW12agtiZjxr4g==",
-      "requires": {
-        "async-disk-cache": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.3.3.tgz",
-        "async-promise-queue": "https://registry.npmjs.org/async-promise-queue/-/async-promise-queue-1.0.4.tgz",
-        "broccoli-plugin": "1.3.0",
-        "fs-tree-diff": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.7.tgz",
-        "hash-for-dep": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
-        "heimdalljs": "0.2.5",
-        "heimdalljs-logger": "0.1.9",
-        "mkdirp": "0.5.1",
-        "promise-map-series": "0.2.3",
-        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-        "rsvp": "3.6.2",
-        "symlink-or-copy": "1.1.8",
-        "walk-sync": "0.3.2"
-      }
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
+      "integrity": "sha512-JwNLDvvXJlhUmr+CHcbVhCyp33NbCIAITjQZmJY9e8QzANXh3jpFWlhSFvkWghwKA8rTAKcXkW12agtiZjxr4g=="
     },
     "broccoli-plugin": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.0.tgz",
-      "integrity": "sha1-vucEqOQtoIy1jlE6qkNu+38O8e4=",
-      "requires": {
-        "promise-map-series": "0.2.3",
-        "quick-temp": "0.1.8",
-        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-        "symlink-or-copy": "1.1.8"
-      }
+      "integrity": "sha1-vucEqOQtoIy1jlE6qkNu+38O8e4="
     },
     "broccoli-sass-source-maps": {
-      "version": "https://registry.npmjs.org/broccoli-sass-source-maps/-/broccoli-sass-source-maps-2.2.0.tgz",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/broccoli-sass-source-maps/-/broccoli-sass-source-maps-2.2.0.tgz",
       "integrity": "sha512-X1yTOGQcjQxYebP+hjeAI286x63VZ0WfgFxqHsr4eimgNNL2TPxkJKKgOaDKJ3nE8pszbJWgHrWpEVXuwgsUzw==",
-      "requires": {
-        "broccoli-caching-writer": "3.0.3",
-        "include-path-searcher": "0.1.0",
-        "mkdirp": "0.3.5",
-        "node-sass": "https://registry.npmjs.org/node-sass/-/node-sass-4.7.2.tgz",
-        "object-assign": "2.1.1",
-        "rsvp": "3.6.2"
-      },
       "dependencies": {
         "mkdirp": {
           "version": "0.3.5",
@@ -1780,10 +1280,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/broccoli-slow-trees/-/broccoli-slow-trees-3.0.1.tgz",
       "integrity": "sha1-m/Kp4vjrPtOj8qvd6YjaQ3zNybQ=",
-      "dev": true,
-      "requires": {
-        "heimdalljs": "0.2.5"
-      }
+      "dev": true
     },
     "broccoli-source": {
       "version": "1.1.0",
@@ -1795,72 +1292,36 @@
       "resolved": "https://registry.npmjs.org/broccoli-sri-hash/-/broccoli-sri-hash-2.1.2.tgz",
       "integrity": "sha1-vGmQXtejga0yXMDQLe0HEyjr8/M=",
       "dev": true,
-      "requires": {
-        "broccoli-caching-writer": "2.3.1",
-        "mkdirp": "0.5.1",
-        "rsvp": "3.6.2",
-        "sri-toolbox": "0.2.0",
-        "symlink-or-copy": "1.1.8"
-      },
       "dependencies": {
         "broccoli-caching-writer": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/broccoli-caching-writer/-/broccoli-caching-writer-2.3.1.tgz",
           "integrity": "sha1-uTz1j5Jk8AMHWGjbBXdPTn8lvQc=",
-          "dev": true,
-          "requires": {
-            "broccoli-kitchen-sink-helpers": "0.2.9",
-            "broccoli-plugin": "1.1.0",
-            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-            "rsvp": "3.6.2",
-            "walk-sync": "0.2.7"
-          }
+          "dev": true
         },
         "broccoli-kitchen-sink-helpers": {
           "version": "0.2.9",
           "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
           "integrity": "sha1-peCYbtjXb7WYS2jD8EUNOpbjbsw=",
-          "dev": true,
-          "requires": {
-            "glob": "5.0.15",
-            "mkdirp": "0.5.1"
-          }
+          "dev": true
         },
         "broccoli-plugin": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.1.0.tgz",
           "integrity": "sha1-c+LPoF+OoeP8FCDEDD2efcckvwI=",
-          "dev": true,
-          "requires": {
-            "promise-map-series": "0.2.3",
-            "quick-temp": "0.1.8",
-            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-            "symlink-or-copy": "1.1.8"
-          }
+          "dev": true
         },
         "glob": {
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true,
-          "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+          "dev": true
         },
         "walk-sync": {
           "version": "0.2.7",
           "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.7.tgz",
           "integrity": "sha1-tJvk7mhnZXrrc2l4tWop0Q+jmWk=",
-          "dev": true,
-          "requires": {
-            "ensure-posix-path": "1.0.2",
-            "matcher-collection": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.5.tgz"
-          }
+          "dev": true
         }
       }
     },
@@ -1869,30 +1330,18 @@
       "resolved": "https://registry.npmjs.org/broccoli-static-compiler/-/broccoli-static-compiler-0.1.4.tgz",
       "integrity": "sha1-cT0Y8I6zExUwV1oMWtKVG7oQr0E=",
       "dev": true,
-      "requires": {
-        "broccoli-kitchen-sink-helpers": "0.2.9",
-        "broccoli-writer": "0.1.1",
-        "mkdirp": "0.3.5"
-      },
       "dependencies": {
         "broccoli-kitchen-sink-helpers": {
           "version": "0.2.9",
           "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
           "integrity": "sha1-peCYbtjXb7WYS2jD8EUNOpbjbsw=",
           "dev": true,
-          "requires": {
-            "glob": "5.0.15",
-            "mkdirp": "0.5.1"
-          },
           "dependencies": {
             "mkdirp": {
               "version": "0.5.1",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-              "dev": true,
-              "requires": {
-                "minimist": "0.0.8"
-              }
+              "dev": true
             }
           }
         },
@@ -1900,14 +1349,7 @@
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true,
-          "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+          "dev": true
         },
         "mkdirp": {
           "version": "0.3.5",
@@ -1920,58 +1362,25 @@
     "broccoli-stew": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/broccoli-stew/-/broccoli-stew-1.5.0.tgz",
-      "integrity": "sha1-16+MGFEdzlEOSdMIpi5Zd/RhiDw=",
-      "requires": {
-        "broccoli-debug": "https://registry.npmjs.org/broccoli-debug/-/broccoli-debug-0.6.4.tgz",
-        "broccoli-funnel": "1.2.0",
-        "broccoli-merge-trees": "1.2.4",
-        "broccoli-persistent-filter": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
-        "broccoli-plugin": "1.3.0",
-        "chalk": "1.1.3",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-        "ensure-posix-path": "1.0.2",
-        "fs-extra": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
-        "minimatch": "3.0.4",
-        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-        "rsvp": "3.6.2",
-        "symlink-or-copy": "1.1.8",
-        "walk-sync": "0.3.2"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
-          "integrity": "sha512-9ztMtDZtSKC78V8mev+k31qaTabbmuH5jatdvPBMikrFHvw5BqlYnQIn/WGK3WHeRooSTkRvLa2IPlaHjPq5Sg==",
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0"
-          }
-        }
-      }
+      "integrity": "sha1-16+MGFEdzlEOSdMIpi5Zd/RhiDw="
     },
     "broccoli-uglify-sourcemap": {
-      "version": "https://registry.npmjs.org/broccoli-uglify-sourcemap/-/broccoli-uglify-sourcemap-2.0.2.tgz",
-      "integrity": "sha512-Fe+qUlPC4gHG7ojQOaRSRrCbrI2niYNAfrZqLkPEXHCi8UtwEqMHBAK6AZylN7ve/0CkGNSxKhCm7ELeeJRI+A==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/broccoli-uglify-sourcemap/-/broccoli-uglify-sourcemap-2.1.1.tgz",
+      "integrity": "sha512-FEp70ji04LGVNFaEsgRHIlPbU1VbYChNv8eZ2SJPOWEzSK+4jsMlkJCcEvQM7eUHWQEVD5O37pWu09wPNy6PYQ==",
       "dev": true,
-      "requires": {
-        "broccoli-plugin": "1.3.0",
-        "debug": "3.1.0",
-        "lodash.defaultsdeep": "4.6.0",
-        "matcher-collection": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.5.tgz",
-        "mkdirp": "0.5.1",
-        "source-map-url": "0.4.0",
-        "symlink-or-copy": "1.1.8",
-        "uglify-es": "3.3.9",
-        "walk-sync": "0.3.2"
-      },
       "dependencies": {
+        "commander": {
+          "version": "2.13.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
+          "dev": true
+        },
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
+          "dev": true
         },
         "source-map": {
           "version": "0.6.1",
@@ -1989,11 +1398,7 @@
           "version": "3.3.9",
           "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
           "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
-          "dev": true,
-          "requires": {
-            "commander": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-            "source-map": "0.6.1"
-          }
+          "dev": true
         }
       }
     },
@@ -2001,28 +1406,24 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/broccoli-writer/-/broccoli-writer-0.1.1.tgz",
       "integrity": "sha1-1NcaqPKvvGejhmuRotp5CEuWqy0=",
-      "dev": true,
-      "requires": {
-        "quick-temp": "0.1.8",
-        "rsvp": "3.6.2"
-      }
+      "dev": true
     },
     "browserslist": {
-      "version": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
-      "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
-      "requires": {
-        "caniuse-lite": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000792.tgz",
-        "electron-to-chromium": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.31.tgz"
-      }
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
+      "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA=="
     },
     "bser": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
       "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
-      "dev": true,
-      "requires": {
-        "node-int64": "0.4.0"
-      }
+      "dev": true
+    },
+    "buffer-from": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
+      "dev": true
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -2046,24 +1447,7 @@
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
-      "requires": {
-        "collection-visit": "1.0.0",
-        "component-emitter": "1.2.1",
-        "get-value": "2.0.6",
-        "has-value": "1.0.0",
-        "isobject": "3.0.1",
-        "set-value": "2.0.0",
-        "to-object-path": "0.3.0",
-        "union-value": "1.0.0",
-        "unset-value": "1.0.0"
-      },
       "dependencies": {
-        "component-emitter": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-          "dev": true
-        },
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
@@ -2076,19 +1460,13 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/calculate-cache-key-for-tree/-/calculate-cache-key-for-tree-1.1.0.tgz",
       "integrity": "sha1-DD5CycE088neU1jA8WeTYn6pdtY=",
-      "dev": true,
-      "requires": {
-        "json-stable-stringify": "1.0.1"
-      }
+      "dev": true
     },
     "caller-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true,
-      "requires": {
-        "callsites": "0.2.0"
-      }
+      "dev": true
     },
     "callsite": {
       "version": "1.0.0",
@@ -2111,10 +1489,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-      "requires": {
-        "camelcase": "2.1.1",
-        "map-obj": "1.0.1"
-      },
       "dependencies": {
         "camelcase": {
           "version": "2.1.1",
@@ -2126,58 +1500,39 @@
     "can-symlink": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/can-symlink/-/can-symlink-1.0.0.tgz",
-      "integrity": "sha1-l7YH2KhLtsbiKLkC2GTstZS50hk=",
-      "requires": {
-        "tmp": "0.0.28"
-      }
+      "integrity": "sha1-l7YH2KhLtsbiKLkC2GTstZS50hk="
     },
     "caniuse-lite": {
-      "version": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000792.tgz",
-      "integrity": "sha512-d+WmDr8VKQPQfyNba0TwGzyJQPgd+W5g6umqFGH7lDKMerC8Ne0gw//P+opYdFTFnBXGh8D+Ok55MKm50TG5MA=="
+      "version": "1.0.30000821",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000821.tgz",
+      "integrity": "sha512-qyYay02wr/5k7PO86W+LKFaEUZfWIvT65PaXuPP16jkSpgZGIsSstHKiYAPVLjTj98j2WnWwZg8CjXPx7UIPYg=="
     },
     "capture-exit": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-1.2.0.tgz",
       "integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
-      "dev": true,
-      "requires": {
-        "rsvp": "3.6.2"
-      }
+      "dev": true
     },
     "cardinal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-1.0.0.tgz",
       "integrity": "sha1-UOIcGwqjdyn5N33vGWtanOyTLuk=",
-      "dev": true,
-      "requires": {
-        "ansicolors": "0.2.1",
-        "redeyed": "1.0.1"
-      }
+      "dev": true
     },
     "caseless": {
-      "version": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-      "integrity": "sha512-ODLXH644w9C2fMPAm7bMDQ3GRvipZWZfKc+8As6hIadRIelE0n0xZuN38NS6kiK3KPEVrpymmQD8bvncAHWQkQ=="
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
     },
     "center-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
-      }
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60="
     },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
-      }
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
     },
     "chardet": {
       "version": "0.4.2",
@@ -2189,25 +1544,20 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/charm/-/charm-1.0.2.tgz",
       "integrity": "sha1-it02cVOm2aWBMxBSxAkJkdqZXjU=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3"
-      }
+      "dev": true
     },
     "chokidar": {
-      "version": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-      "integrity": "sha512-mk8fAWcRUOxY7btlLtitj3A45jOwSAxH4tOFOoEGbVsl6cL6pPMWUy7dwZ/canfj3QEdP6FHSnf/l1c6/WkzVg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+      "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "dev": true,
-      "requires": {
-        "anymatch": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-        "async-each": "1.0.1",
-        "fsevents": "1.1.3",
-        "glob-parent": "2.0.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "2.0.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0"
+      "dependencies": {
+        "anymatch": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+          "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+          "dev": true
+        }
       }
     },
     "circular-json": {
@@ -2217,51 +1567,34 @@
       "dev": true
     },
     "clap": {
-      "version": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
       "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
-      "dev": true,
-      "requires": {
-        "chalk": "1.1.3"
-      }
+      "dev": true
     },
     "class-utils": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
-      "requires": {
-        "arr-union": "3.1.0",
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "static-extend": "0.1.2"
-      },
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true,
-          "requires": {
-            "is-descriptor": "0.1.6"
-          }
+          "dev": true
         },
         "is-accessor-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz"
-              }
+              "dev": true
             }
           }
         },
@@ -2270,18 +1603,12 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz"
-              }
+              "dev": true
             }
           }
         },
@@ -2289,12 +1616,7 @@
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
-          }
+          "dev": true
         },
         "isobject": {
           "version": "3.0.1",
@@ -2321,28 +1643,18 @@
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.28.tgz",
       "integrity": "sha1-vxlF6C/ICPVWlebd6uwBQA79A/8=",
       "dev": true,
-      "requires": {
-        "commander": "2.8.1",
-        "source-map": "0.4.4"
-      },
       "dependencies": {
         "commander": {
           "version": "2.8.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
-          "dev": true,
-          "requires": {
-            "graceful-readlink": "1.0.1"
-          }
+          "dev": true
         },
         "source-map": {
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
+          "dev": true
         }
       }
     },
@@ -2350,25 +1662,18 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/clean-css-promise/-/clean-css-promise-0.1.1.tgz",
       "integrity": "sha1-Q/PSyN/LK/BxSBJSzZt2QzwI7ss=",
-      "dev": true,
-      "requires": {
-        "array-to-error": "1.1.1",
-        "clean-css": "3.4.28",
-        "pinkie-promise": "2.0.1"
-      }
+      "dev": true
     },
     "cli-cursor": {
-      "version": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-      "integrity": "sha512-25tABq090YNKkF6JH7lcwO0zFJTRke4Jcq9iX2nr/Sz0Cjjv4gckmwlW6Ty/aoyFd6z3ysR2hMGC2GFugmBo6A==",
-      "dev": true,
-      "requires": {
-        "restore-cursor": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz"
-      }
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "dev": true
     },
     "cli-spinners": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.1.0.tgz",
-      "integrity": "sha1-8YR7FohE2RemceudFH499JfJDQY=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.3.0.tgz",
+      "integrity": "sha512-ahr3q/EW26uLN3vqBaDQS4g1rUwKMbVSTRlyfyoY06VwwSJmMYRxhT3FTAiTz9Yam6OOb1e0ldwvbsnuThvuzA==",
       "dev": true
     },
     "cli-table": {
@@ -2376,9 +1681,6 @@
       "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
       "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
       "dev": true,
-      "requires": {
-        "colors": "1.0.3"
-      },
       "dependencies": {
         "colors": {
           "version": "1.0.3",
@@ -2393,11 +1695,6 @@
       "resolved": "https://registry.npmjs.org/cli-table2/-/cli-table2-0.2.0.tgz",
       "integrity": "sha1-LR738hig54biFFQFYtS9F3/jLZc=",
       "dev": true,
-      "requires": {
-        "colors": "1.1.2",
-        "lodash": "3.10.1",
-        "string-width": "1.0.2"
-      },
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
@@ -2408,24 +1705,20 @@
       }
     },
     "cli-width": {
-      "version": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-      "integrity": "sha512-EJLbKSuvHTrVRynOXCYFTbQKZOFXWNe3/6DN1yrEH3TuuZT1x4dMQnCHnfCrBUUiGjO63enEIfaB17VaRl2d4A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
     "cliui": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-      "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
-        "wordwrap": "0.0.2"
-      }
+      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE="
     },
     "clone": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-      "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
     },
     "co": {
       "version": "4.6.0",
@@ -2437,10 +1730,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
       "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
-      "dev": true,
-      "requires": {
-        "q": "https://registry.npmjs.org/q/-/q-1.5.1.tgz"
-      }
+      "dev": true
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -2451,20 +1741,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
-      "dev": true,
-      "requires": {
-        "map-visit": "1.0.0",
-        "object-visit": "1.0.1"
-      }
+      "dev": true
     },
     "color-convert": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-      "dev": true,
-      "requires": {
-        "color-name": "1.1.3"
-      }
+      "dev": true
     },
     "color-name": {
       "version": "1.1.3",
@@ -2473,46 +1756,32 @@
       "dev": true
     },
     "colors": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
-      "dev": true
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.1.tgz",
+      "integrity": "sha512-s8+wktIuDSLffCywiwSxQOMqtPxML11a/dtHE17tMn4B1MSWw/C22EKf7M2KGUBcDaVFEGT+S8N02geDXeuNKg==",
+      "dev": true,
+      "optional": true
     },
     "combined-stream": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-      "requires": {
-        "delayed-stream": "1.0.0"
-      }
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg="
     },
     "commander": {
-      "version": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-      "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
     },
     "common-tags": {
-      "version": "https://registry.npmjs.org/common-tags/-/common-tags-1.7.2.tgz",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.7.2.tgz",
       "integrity": "sha512-joj9ZlUOjCrwdbmiLqafeUSgkUM74NqhLsZtSqDmhKudaIY197zTrb8JMl31fMnCUuxwFT23eC/oWvrZzDLRJQ==",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz"
-      }
+      "dev": true
     },
     "commoner": {
       "version": "0.10.8",
       "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
       "integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
-      "requires": {
-        "commander": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-        "detective": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
-        "glob": "5.0.15",
-        "graceful-fs": "4.1.11",
-        "iconv-lite": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-        "mkdirp": "0.5.1",
-        "private": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-        "q": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-        "recast": "0.11.23"
-      },
       "dependencies": {
         "esprima": {
           "version": "3.1.3",
@@ -2522,25 +1791,12 @@
         "glob": {
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E="
         },
         "recast": {
           "version": "0.11.23",
           "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
-          "integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
-          "requires": {
-            "ast-types": "0.9.6",
-            "esprima": "3.1.3",
-            "private": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
-          }
+          "integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM="
         }
       }
     },
@@ -2551,9 +1807,9 @@
       "dev": true
     },
     "component-emitter": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
-      "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
       "dev": true
     },
     "component-inherit": {
@@ -2563,27 +1819,16 @@
       "dev": true
     },
     "compressible": {
-      "version": "https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz",
-      "integrity": "sha512-trmYwdSyr8Pq69/84tAxuipERuqNuhRpSzp9LS5bS4kdaAiBPg4bsPJZ7ExCv+4XJuifeTc3diW19spabrEweQ==",
-      "dev": true,
-      "requires": {
-        "mime-db": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz"
-      }
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.13.tgz",
+      "integrity": "sha1-DRAgq5JLL9tNYnmHXH1tq6a6p6k=",
+      "dev": true
     },
     "compression": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.1.tgz",
-      "integrity": "sha1-7/JgPvwuIs+G810uuTWJ+YdTc9s=",
-      "dev": true,
-      "requires": {
-        "accepts": "1.3.4",
-        "bytes": "3.0.0",
-        "compressible": "https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-        "on-headers": "1.0.1",
-        "safe-buffer": "5.1.1",
-        "vary": "1.1.2"
-      }
+      "version": "1.7.2",
+      "resolved": "http://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
+      "integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -2591,29 +1836,16 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "typedarray": "0.0.6"
-      }
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true
     },
     "configstore": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
-      "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
-      "dev": true,
-      "requires": {
-        "dot-prop": "4.2.0",
-        "graceful-fs": "4.1.11",
-        "make-dir": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
-        "unique-string": "1.0.0",
-        "write-file-atomic": "2.3.0",
-        "xdg-basedir": "3.0.0"
-      }
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
+      "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
+      "dev": true
     },
     "console-control-strings": {
       "version": "1.1.0",
@@ -2621,52 +1853,28 @@
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
     "console-ui": {
-      "version": "https://registry.npmjs.org/console-ui/-/console-ui-2.1.0.tgz",
-      "integrity": "sha512-/FqFHRwYVjjdeLd/1lhRsyoPCMtDMREJfPU6WCN9LMxPWu3++Cr2wN1uIZfbefVwr59is4UBd6Z2vaJRzTyPWQ==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/console-ui/-/console-ui-2.2.2.tgz",
+      "integrity": "sha1-spSik03oad0GeJq0vmlVVBHt7yk=",
       "dev": true,
-      "requires": {
-        "chalk": "2.3.2",
-        "inquirer": "https://registry.npmjs.org/inquirer/-/inquirer-2.0.0.tgz",
-        "json-stable-stringify": "1.0.1",
-        "ora": "1.3.0",
-        "through": "2.3.8",
-        "user-info": "https://registry.npmjs.org/user-info/-/user-info-1.0.0.tgz"
-      },
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
+          "dev": true
         },
         "chalk": {
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.3.0"
-          }
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
         "supports-color": {
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
-          "dev": true,
-          "requires": {
-            "has-flag": "3.0.0"
-          }
+          "dev": true
         }
       }
     },
@@ -2675,9 +1883,6 @@
       "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.14.5.tgz",
       "integrity": "sha1-WiUEe8dvcwcmZ8jLUsmJiI9JTGM=",
       "dev": true,
-      "requires": {
-        "bluebird": "3.5.1"
-      },
       "dependencies": {
         "bluebird": {
           "version": "3.5.1",
@@ -2706,8 +1911,9 @@
       "dev": true
     },
     "convert-source-map": {
-      "version": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-      "integrity": "sha512-LNHI/Ll1UqBTGhrR6vMhtVZmX4kjYdCJUjIM6Ydp7/oJ5w1C0MKrzELuUAmMlU0eKwBGx6PaO0TRZ/KDXAFTBg=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
     },
     "cookie": {
       "version": "0.3.1",
@@ -2734,56 +1940,33 @@
       "dev": true
     },
     "core-js": {
-      "version": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-      "integrity": "sha512-1fhTiNuC8YWzCl567b1K2mQqRyHvQtRlEuNY31t837BFNd57oMvElJTsM5IrIooczeG/KvssBbJi2ZZASwyMIQ=="
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.4.tgz",
+      "integrity": "sha1-8si/GB8qgLkvNgEhQpzmOi8K6uA="
     },
     "core-object": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/core-object/-/core-object-3.1.5.tgz",
       "integrity": "sha512-sA2/4+/PZ/KV6CKgjrVrrUVBKCkdDO02CUlQ0YKTQoYUwPYNOtOAcWlbYhd5v/1JqYaA6oZ4sDlOU4ppVw6Wbg==",
       "dev": true,
-      "requires": {
-        "chalk": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz"
-      },
       "dependencies": {
         "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          },
-          "dependencies": {
-            "color-convert": {
-              "version": "1.9.1",
-              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-              "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-              "dev": true,
-              "requires": {
-                "color-name": "1.1.3"
-              }
-            }
-          }
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true
         },
         "chalk": {
-          "version": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
-          }
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+          "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "dev": true
         }
       }
     },
@@ -2795,19 +1978,12 @@
     "cross-spawn": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
-      "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
-      "requires": {
-        "lru-cache": "4.1.1",
-        "which": "https://registry.npmjs.org/which/-/which-1.3.0.tgz"
-      }
+      "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI="
     },
     "cryptiles": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "requires": {
-        "boom": "2.10.1"
-      }
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g="
     },
     "crypto-random-string": {
       "version": "1.0.0",
@@ -2819,19 +1995,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/csso/-/csso-2.0.0.tgz",
       "integrity": "sha1-F4tDpEYhIhwndWCG9THgL0KQDug=",
-      "dev": true,
-      "requires": {
-        "clap": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
-        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
-      }
+      "dev": true
     },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-      "requires": {
-        "array-find-index": "1.0.2"
-      }
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o="
     },
     "dag-map": {
       "version": "2.0.2",
@@ -2843,9 +2012,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "requires": {
-        "assert-plus": "1.0.0"
-      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -2855,11 +2021,9 @@
       }
     },
     "debug": {
-      "version": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "requires": {
-        "ms": "2.0.0"
-      }
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="
     },
     "decamelize": {
       "version": "1.2.0",
@@ -2878,15 +2042,25 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "defaults": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "dev": true,
+      "dependencies": {
+        "clone": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+          "dev": true
+        }
+      }
+    },
     "define-property": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "dev": true,
-      "requires": {
-        "is-descriptor": "1.0.2",
-        "isobject": "3.0.1"
-      },
       "dependencies": {
         "isobject": {
           "version": "3.0.1",
@@ -2904,34 +2078,13 @@
     "defs": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
-      "integrity": "sha1-siYJ8sehG6ej2xFoBcE5scr/qdI=",
-      "requires": {
-        "alter": "0.2.0",
-        "ast-traverse": "0.1.1",
-        "breakable": "1.0.0",
-        "esprima-fb": "15001.1001.0-dev-harmony-fb",
-        "simple-fmt": "0.1.0",
-        "simple-is": "0.2.0",
-        "stringmap": "0.2.2",
-        "stringset": "0.2.1",
-        "tryor": "0.1.2",
-        "yargs": "3.27.0"
-      }
+      "integrity": "sha1-siYJ8sehG6ej2xFoBcE5scr/qdI="
     },
     "del": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true,
-      "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz"
-      }
+      "dev": true
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -2944,8 +2097,9 @@
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
     },
     "depd": {
-      "version": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
       "dev": true
     },
     "destroy": {
@@ -2958,55 +2112,46 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
       "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
-      "dev": true,
-      "requires": {
-        "fs-exists-sync": "0.1.0"
-      }
+      "dev": true
     },
     "detect-indent": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-      "requires": {
-        "repeating": "2.0.1"
-      }
+      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg="
     },
     "detective": {
-      "version": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
-      "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
-      "requires": {
-        "acorn": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
-        "defined": "1.0.0"
-      }
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
+      "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig=="
     },
     "diff": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
-      "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
+    "doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true
     },
     "dot-prop": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
       "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
-      "dev": true,
-      "requires": {
-        "is-obj": "1.0.1"
-      }
+      "dev": true
     },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "optional": true,
-      "requires": {
-        "jsbn": "0.1.1"
-      }
+      "optional": true
     },
     "editions": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.3.tgz",
-      "integrity": "sha1-CQcQG92iD6w8vjNMJ8vQaI3Jmls="
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+      "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
     },
     "ee-first": {
       "version": "1.1.1",
@@ -3015,67 +2160,44 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.31.tgz",
-      "integrity": "sha512-XE4CLbswkZgZFn34cKFy1xaX+F5LHxeDLjY1+rsK9asDzknhbrd9g/n/01/acbU25KTsUSiLKwvlLyA+6XLUOA=="
+      "version": "1.3.41",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.41.tgz",
+      "integrity": "sha1-fjNkPgDNhe39F+BBlPbQDnNzcjU="
     },
     "ember-assign-helper": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ember-assign-helper/-/ember-assign-helper-0.1.2.tgz",
-      "integrity": "sha1-PR1XXz1EV7NmKyFNTG5nG9RiytA=",
-      "requires": {
-        "ember-cli-babel": "6.6.0"
-      }
+      "integrity": "sha1-PR1XXz1EV7NmKyFNTG5nG9RiytA="
     },
     "ember-basic-dropdown": {
       "version": "0.32.9",
       "resolved": "https://registry.npmjs.org/ember-basic-dropdown/-/ember-basic-dropdown-0.32.9.tgz",
       "integrity": "sha1-ta2Y7XoH3OoJi2RAJ0W2YrGDWlE=",
       "dev": true,
-      "requires": {
-        "ember-cli-babel": "6.6.0",
-        "ember-cli-htmlbars": "1.3.4",
-        "ember-native-dom-helpers": "0.5.4",
-        "ember-wormhole": "https://registry.npmjs.org/ember-wormhole/-/ember-wormhole-0.5.4.tgz"
-      },
       "dependencies": {
         "amd-name-resolver": {
           "version": "0.0.7",
           "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-0.0.7.tgz",
           "integrity": "sha1-gUMBrf6KLxCfboTV6TUZbvtmlhU=",
-          "dev": true,
-          "requires": {
-            "ensure-posix-path": "1.0.2"
-          }
+          "dev": true
         },
         "babel-plugin-ember-modules-api-polyfill": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.3.0.tgz",
           "integrity": "sha512-cv5ZimF5X52uW7Ul83UUxtsFZE6rZYkMv6qWnAeiDLT1/KtpVrTkJpwzDlvJ/FhKJZ43ih4GbFbhuhBKKT7vIw==",
-          "dev": true,
-          "requires": {
-            "ember-rfc176-data": "0.3.1"
-          }
+          "dev": true
         },
         "ember-cli-htmlbars": {
           "version": "1.3.4",
           "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-1.3.4.tgz",
           "integrity": "sha512-5lycG6z35QHr3WZF1OkVvT+N/GGAVuemtM6m8NUgBWoeA2TqOgPFRcI0eRqoLA0HAfe0R2MReKmMI7y1LEM1+w==",
-          "dev": true,
-          "requires": {
-            "broccoli-persistent-filter": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
-            "ember-cli-version-checker": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-            "hash-for-dep": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
-            "json-stable-stringify": "1.0.1",
-            "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
-          }
+          "dev": true
         },
         "ember-cli-version-checker": {
-          "version": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-          "integrity": "sha512-mu1Apdd19ZuDsy9WAHheFhltaJx+0ardFNM8Hb/AeRO9RokOK/bdUq/Jc1oeg0/Hl18tnxg8STG9TyJ6HgE3+g==",
-          "dev": true,
-          "requires": {
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
-          }
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
+          "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
+          "dev": true
         },
         "ember-rfc176-data": {
           "version": "0.3.1",
@@ -3084,56 +2206,28 @@
           "dev": true
         },
         "ember-wormhole": {
-          "version": "https://registry.npmjs.org/ember-wormhole/-/ember-wormhole-0.5.4.tgz",
-          "integrity": "sha512-VqQak7FJxo+xQGxcOJ9epevrykir9BG7nwLWD3ygc/ftHcs+9vOsar61cfQWrVoUm0l76EFD4bTmjTiHwOGUuw==",
+          "version": "0.5.4",
+          "resolved": "https://registry.npmjs.org/ember-wormhole/-/ember-wormhole-0.5.4.tgz",
+          "integrity": "sha1-lo6A8JNJT0rtJm51CvpjkZxhOD0=",
           "dev": true,
-          "requires": {
-            "ember-cli-babel": "6.12.0",
-            "ember-cli-htmlbars": "2.0.3"
-          },
           "dependencies": {
             "ember-cli-babel": {
               "version": "6.12.0",
               "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.12.0.tgz",
               "integrity": "sha512-LMwZ3Xf3Q3jQUXaJtLLJsbbhRZRNv/iea64lZ8OgqZp1fh66CSXfmqV3L9QSuYQKPDNqFiu2v6IpOT08C6GU6w==",
-              "dev": true,
-              "requires": {
-                "amd-name-resolver": "0.0.7",
-                "babel-plugin-debug-macros": "0.1.11",
-                "babel-plugin-ember-modules-api-polyfill": "2.3.0",
-                "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-                "babel-polyfill": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
-                "babel-preset-env": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
-                "broccoli-babel-transpiler": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.1.2.tgz",
-                "broccoli-debug": "https://registry.npmjs.org/broccoli-debug/-/broccoli-debug-0.6.4.tgz",
-                "broccoli-funnel": "1.2.0",
-                "broccoli-source": "1.1.0",
-                "clone": "2.1.1",
-                "ember-cli-version-checker": "2.1.0",
-                "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
-              }
+              "dev": true
             },
             "ember-cli-htmlbars": {
               "version": "2.0.3",
               "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-2.0.3.tgz",
               "integrity": "sha512-oyWtJebOwxAqWZwMc0NKFJ8FJdxVixM7zl0FaXq1vTAG6bOgnU7yAhXEASlaO5f+PptZueZfOpdpvRwZW/Gk1A==",
-              "dev": true,
-              "requires": {
-                "broccoli-persistent-filter": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
-                "hash-for-dep": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
-                "json-stable-stringify": "1.0.1",
-                "strip-bom": "3.0.0"
-              }
+              "dev": true
             },
             "ember-cli-version-checker": {
               "version": "2.1.0",
               "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz",
               "integrity": "sha512-ssiNyVTp+PphroFum8guHX9py4xU1PCxkRYgb25NxumgjpKTPjhkgTfpRRKXlIQe+/wVMmhf+Uv6w9vSLZKWKQ==",
-              "dev": true,
-              "requires": {
-                "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-                "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
-              }
+              "dev": true
             },
             "strip-bom": {
               "version": "3.0.0",
@@ -3144,12 +2238,10 @@
           }
         },
         "strip-bom": {
-          "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g==",
-          "dev": true,
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true
         }
       }
     },
@@ -3158,193 +2250,66 @@
       "resolved": "https://registry.npmjs.org/ember-cli/-/ember-cli-2.16.2.tgz",
       "integrity": "sha1-U7kiBzqObzQlWm4NyxeUqRuj4bc=",
       "dev": true,
-      "requires": {
-        "amd-name-resolver": "1.0.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "bower-config": "1.4.1",
-        "bower-endpoint-parser": "0.2.2",
-        "broccoli-babel-transpiler": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.1.2.tgz",
-        "broccoli-brocfile-loader": "0.18.0",
-        "broccoli-builder": "https://registry.npmjs.org/broccoli-builder/-/broccoli-builder-0.18.11.tgz",
-        "broccoli-concat": "3.2.2",
-        "broccoli-config-loader": "1.0.1",
-        "broccoli-config-replace": "1.1.2",
-        "broccoli-debug": "https://registry.npmjs.org/broccoli-debug/-/broccoli-debug-0.6.4.tgz",
-        "broccoli-funnel": "2.0.1",
-        "broccoli-funnel-reducer": "1.0.0",
-        "broccoli-merge-trees": "2.0.0",
-        "broccoli-middleware": "1.0.0",
-        "broccoli-source": "1.1.0",
-        "broccoli-stew": "1.5.0",
-        "calculate-cache-key-for-tree": "1.1.0",
-        "capture-exit": "1.2.0",
-        "chalk": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-        "clean-base-url": "1.0.0",
-        "compression": "1.7.1",
-        "configstore": "3.1.1",
-        "console-ui": "https://registry.npmjs.org/console-ui/-/console-ui-2.1.0.tgz",
-        "core-object": "3.1.5",
-        "dag-map": "2.0.2",
-        "diff": "3.4.0",
-        "ember-cli-broccoli-sane-watcher": "2.0.4",
-        "ember-cli-is-package-missing": "1.0.0",
-        "ember-cli-legacy-blueprints": "0.1.5",
-        "ember-cli-lodash-subset": "2.0.1",
-        "ember-cli-normalize-entity-name": "1.0.0",
-        "ember-cli-preprocess-registry": "3.1.1",
-        "ember-cli-string-utils": "1.1.0",
-        "ember-try": "https://registry.npmjs.org/ember-try/-/ember-try-0.2.23.tgz",
-        "ensure-posix-path": "1.0.2",
-        "execa": "0.8.0",
-        "exists-sync": "0.0.4",
-        "exit": "0.1.2",
-        "express": "4.16.2",
-        "filesize": "https://registry.npmjs.org/filesize/-/filesize-3.5.11.tgz",
-        "find-up": "2.1.0",
-        "fs-extra": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
-        "fs-tree-diff": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.7.tgz",
-        "get-caller-file": "1.0.2",
-        "git-repo-info": "1.4.1",
-        "glob": "7.1.1",
-        "heimdalljs": "0.2.5",
-        "heimdalljs-fs-monitor": "0.1.0",
-        "heimdalljs-graph": "https://registry.npmjs.org/heimdalljs-graph/-/heimdalljs-graph-0.3.4.tgz",
-        "heimdalljs-logger": "0.1.9",
-        "http-proxy": "1.16.2",
-        "inflection": "1.12.0",
-        "is-git-url": "https://registry.npmjs.org/is-git-url/-/is-git-url-1.0.0.tgz",
-        "isbinaryfile": "3.0.2",
-        "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-        "json-stable-stringify": "1.0.1",
-        "leek": "0.0.24",
-        "lodash.template": "4.4.0",
-        "markdown-it": "8.4.0",
-        "markdown-it-terminal": "0.1.0",
-        "minimatch": "3.0.4",
-        "morgan": "1.9.0",
-        "node-modules-path": "1.0.1",
-        "nopt": "3.0.6",
-        "npm-package-arg": "4.2.1",
-        "portfinder": "1.0.13",
-        "promise-map-series": "0.2.3",
-        "quick-temp": "0.1.8",
-        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-        "rsvp": "3.6.2",
-        "sane": "1.7.0",
-        "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-        "silent-error": "1.1.0",
-        "sort-package-json": "1.7.1",
-        "symlink-or-copy": "1.1.8",
-        "temp": "0.8.3",
-        "testem": "1.18.4",
-        "tiny-lr": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-1.1.0.tgz",
-        "tree-sync": "1.2.2",
-        "uuid": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-        "validate-npm-package-name": "3.0.0",
-        "walk-sync": "0.3.2",
-        "yam": "0.0.22"
-      },
       "dependencies": {
         "amd-name-resolver": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-1.0.0.tgz",
           "integrity": "sha1-Dlk7KNb6MyarF5gQftrqlhBG6Ng=",
-          "dev": true,
-          "requires": {
-            "ensure-posix-path": "1.0.2"
-          }
+          "dev": true
         },
         "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz"
-          },
-          "dependencies": {
-            "color-convert": {
-              "version": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-              "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-              "dev": true,
-              "requires": {
-                "color-name": "1.1.3"
-              }
-            }
-          }
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true
         },
         "broccoli-funnel": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.1.tgz",
           "integrity": "sha512-C8Lnp9TVsSSiZMGEF16C0dCiNg2oJqUKwuZ1K4kVC6qRPG/2Cj/rtB5kRCC9qEbwqhX71bDbfHROx0L3J7zXQg==",
-          "dev": true,
-          "requires": {
-            "array-equal": "1.0.0",
-            "blank-object": "1.0.2",
-            "broccoli-plugin": "1.3.0",
-            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.7.tgz",
-            "heimdalljs": "0.2.5",
-            "minimatch": "3.0.4",
-            "mkdirp": "0.5.1",
-            "path-posix": "1.0.0",
-            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-            "symlink-or-copy": "1.1.8",
-            "walk-sync": "0.3.2"
-          }
+          "dev": true
         },
         "broccoli-merge-trees": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.0.tgz",
           "integrity": "sha1-EK6kbdXOvMi499WlTwqEpPC7kLk=",
-          "dev": true,
-          "requires": {
-            "broccoli-plugin": "1.3.0",
-            "merge-trees": "1.0.1"
-          }
+          "dev": true
         },
         "chalk": {
-          "version": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
-          }
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+          "dev": true
         },
         "find-up": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
-          "requires": {
-            "locate-path": "2.0.0"
-          }
+          "dev": true
+        },
+        "fs-extra": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+          "dev": true
         },
         "glob": {
           "version": "7.1.1",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+          "dev": true
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "dev": true
         }
       }
     },
@@ -3353,139 +2318,219 @@
       "resolved": "https://registry.npmjs.org/ember-cli-app-version/-/ember-cli-app-version-3.0.0.tgz",
       "integrity": "sha1-1nozrux70DGH++csVmPa3sTDNoo=",
       "dev": true,
-      "requires": {
-        "ember-cli-babel": "6.6.0",
-        "ember-cli-htmlbars": "1.3.4",
-        "git-repo-version": "0.4.1"
-      },
       "dependencies": {
         "ember-cli-htmlbars": {
           "version": "1.3.4",
           "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-1.3.4.tgz",
           "integrity": "sha512-5lycG6z35QHr3WZF1OkVvT+N/GGAVuemtM6m8NUgBWoeA2TqOgPFRcI0eRqoLA0HAfe0R2MReKmMI7y1LEM1+w==",
-          "dev": true,
-          "requires": {
-            "broccoli-persistent-filter": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
-            "ember-cli-version-checker": "1.3.1",
-            "hash-for-dep": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
-            "json-stable-stringify": "1.0.1",
-            "strip-bom": "2.0.0"
-          },
-          "dependencies": {
-            "ember-cli-version-checker": {
-              "version": "1.3.1",
-              "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-              "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
-              "dev": true,
-              "requires": {
-                "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
-              }
-            },
-            "strip-bom": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-              "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-              "dev": true,
-              "requires": {
-                "is-utf8": "0.2.1"
-              }
-            }
-          }
+          "dev": true
+        },
+        "ember-cli-version-checker": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
+          "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
+          "dev": true
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true
         }
       }
     },
     "ember-cli-babel": {
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.6.0.tgz",
-      "integrity": "sha1-qDYrxEhBv9+Js4nzGX8QTXulJto=",
-      "requires": {
-        "amd-name-resolver": "0.0.6",
-        "babel-plugin-debug-macros": "0.1.11",
-        "babel-plugin-ember-modules-api-polyfill": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-1.6.0.tgz",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-polyfill": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
-        "babel-preset-env": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
-        "broccoli-babel-transpiler": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.1.2.tgz",
-        "broccoli-debug": "https://registry.npmjs.org/broccoli-debug/-/broccoli-debug-0.6.4.tgz",
-        "broccoli-funnel": "1.2.0",
-        "broccoli-source": "1.1.0",
-        "clone": "2.1.1",
-        "ember-cli-version-checker": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz"
-      }
+      "integrity": "sha1-qDYrxEhBv9+Js4nzGX8QTXulJto="
     },
     "ember-cli-broccoli-sane-watcher": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/ember-cli-broccoli-sane-watcher/-/ember-cli-broccoli-sane-watcher-2.0.4.tgz",
-      "integrity": "sha1-9D9C91t1CcIS+5Js2a6oauGSZMY=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-broccoli-sane-watcher/-/ember-cli-broccoli-sane-watcher-2.1.1.tgz",
+      "integrity": "sha512-fG2AbvtNVXoV05wf2svN8SoEnpZrMbxL6t7g+a1FSySfe0lkTvF94s8Zwa5fJKyQV8/HyKD8iWQcJGOp3DxPKA==",
       "dev": true,
-      "requires": {
-        "broccoli-slow-trees": "3.0.1",
-        "heimdalljs": "0.2.5",
-        "heimdalljs-logger": "0.1.9",
-        "rsvp": "3.6.2",
-        "sane": "1.7.0"
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "braces": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.1.tgz",
+          "integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
+          "dev": true,
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true
+            }
+          }
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "dev": true,
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "dev": true
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "dev": true,
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true
+            }
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "dev": true,
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true
+            }
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "dev": true,
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true
+            }
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true
+            }
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "sane": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/sane/-/sane-2.5.0.tgz",
+          "integrity": "sha512-glfKd7YH4UCrh/7dD+UESsr8ylKWRE7UQPoXuz28FgmcF0ViJQhCTCCZHICRKxf8G8O1KdLEn20dcICK54c7ew==",
+          "dev": true
+        }
       }
     },
     "ember-cli-countries": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/ember-cli-countries/-/ember-cli-countries-0.0.3.tgz",
       "integrity": "sha1-Y+zNyH04TDFTn3/SrU3TWQnUYJA=",
-      "requires": {
-        "ember-cli-babel": "5.2.4"
-      },
       "dependencies": {
         "babel-core": {
           "version": "5.8.38",
           "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
-          "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
-          "requires": {
-            "babel-plugin-constant-folding": "1.0.1",
-            "babel-plugin-dead-code-elimination": "1.0.2",
-            "babel-plugin-eval": "1.0.1",
-            "babel-plugin-inline-environment-variables": "1.0.1",
-            "babel-plugin-jscript": "1.0.4",
-            "babel-plugin-member-expression-literals": "1.0.1",
-            "babel-plugin-property-literals": "1.0.1",
-            "babel-plugin-proto-to-assign": "1.0.4",
-            "babel-plugin-react-constant-elements": "1.0.3",
-            "babel-plugin-react-display-name": "1.0.3",
-            "babel-plugin-remove-console": "1.0.1",
-            "babel-plugin-remove-debugger": "1.0.1",
-            "babel-plugin-runtime": "1.0.7",
-            "babel-plugin-undeclared-variables-check": "1.0.2",
-            "babel-plugin-undefined-to-void": "1.1.6",
-            "babylon": "5.8.38",
-            "bluebird": "2.11.0",
-            "chalk": "1.1.3",
-            "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-            "core-js": "1.2.7",
-            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "detect-indent": "3.0.1",
-            "esutils": "2.0.2",
-            "fs-readdir-recursive": "0.1.2",
-            "globals": "6.4.1",
-            "home-or-tmp": "1.0.0",
-            "is-integer": "1.0.7",
-            "js-tokens": "1.0.1",
-            "json5": "0.4.0",
-            "lodash": "3.10.1",
-            "minimatch": "2.0.10",
-            "output-file-sync": "1.1.2",
-            "path-exists": "1.0.0",
-            "path-is-absolute": "1.0.1",
-            "private": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-            "regenerator": "0.8.40",
-            "regexpu": "1.3.0",
-            "repeating": "1.1.3",
-            "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-            "shebang-regex": "1.0.0",
-            "slash": "1.0.0",
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-            "source-map-support": "0.2.10",
-            "to-fast-properties": "1.0.3",
-            "trim-right": "1.0.1",
-            "try-resolve": "1.0.1"
-          }
+          "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg="
         },
         "babylon": {
           "version": "5.8.38",
@@ -3493,20 +2538,9 @@
           "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0="
         },
         "broccoli-babel-transpiler": {
-          "version": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.2.tgz",
-          "integrity": "sha512-vFQ+aSR9J81fm3MXXQGgDxswYINHl2p5duLvRLVnpmgPDNdpdsa30gh3xnmhzR/GwWFBfUNle7aYxthlgvsN0w==",
-          "requires": {
-            "babel-core": "5.8.38",
-            "broccoli-funnel": "1.2.0",
-            "broccoli-merge-trees": "1.2.4",
-            "broccoli-persistent-filter": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
-            "clone": "0.2.0",
-            "hash-for-dep": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
-            "heimdalljs-logger": "0.1.9",
-            "json-stable-stringify": "1.0.1",
-            "rsvp": "3.6.2",
-            "workerpool": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.0.tgz"
-          },
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.4.tgz",
+          "integrity": "sha512-gI14Pqc4qbmn5RW4SuAmybLiOoYW59D+HzQyhY6WdaGMAjikKBwJN0p17phyvafQ+kvG0mUiMd83lgHLeATnEA==",
           "dependencies": {
             "clone": {
               "version": "0.2.0",
@@ -3523,31 +2557,17 @@
         "detect-indent": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-          "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
-          "requires": {
-            "get-stdin": "4.0.1",
-            "minimist": "1.2.0",
-            "repeating": "1.1.3"
-          }
+          "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U="
         },
         "ember-cli-babel": {
-          "version": "5.2.4",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz",
-          "integrity": "sha1-XOT0awjtb20h6Hhhn7aJcZ1ujhM=",
-          "requires": {
-            "broccoli-babel-transpiler": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.2.tgz",
-            "broccoli-funnel": "1.2.0",
-            "clone": "2.1.1",
-            "ember-cli-version-checker": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-            "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz"
-          }
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.8.tgz",
+          "integrity": "sha512-Mt9OOB5RaZwjde+LYef8EgwNVCAzsYDv4ktshblaXxr4m/Xm5/7/rxEu42RNrYkoy/qWpT9uhaD+JKK4riMf+w=="
         },
         "ember-cli-version-checker": {
-          "version": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-          "integrity": "sha512-mu1Apdd19ZuDsy9WAHheFhltaJx+0ardFNM8Hb/AeRO9RokOK/bdUq/Jc1oeg0/Hl18tnxg8STG9TyJ6HgE3+g==",
-          "requires": {
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
-          }
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
+          "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI="
         },
         "globals": {
           "version": "6.4.1",
@@ -3557,11 +2577,7 @@
         "home-or-tmp": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-          "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
-          "requires": {
-            "os-tmpdir": "1.0.2",
-            "user-home": "1.1.1"
-          }
+          "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU="
         },
         "js-tokens": {
           "version": "1.0.1",
@@ -3581,10 +2597,7 @@
         "minimatch": {
           "version": "2.0.10",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
+          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc="
         },
         "minimist": {
           "version": "1.2.0",
@@ -3594,26 +2607,17 @@
         "repeating": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-          "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
-          "requires": {
-            "is-finite": "1.0.2"
-          }
+          "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw="
         },
         "source-map-support": {
           "version": "0.2.10",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
           "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
-          "requires": {
-            "source-map": "0.1.32"
-          },
           "dependencies": {
             "source-map": {
               "version": "0.1.32",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-              "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
-              "requires": {
-                "amdefine": "1.0.1"
-              }
+              "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY="
             }
           }
         }
@@ -3623,366 +2627,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ember-cli-dependency-checker/-/ember-cli-dependency-checker-2.0.0.tgz",
       "integrity": "sha1-8vL/FErM50R83n4Khmbb/lApo1U=",
-      "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "is-git-url": "https://registry.npmjs.org/is-git-url/-/is-git-url-1.0.0.tgz",
-        "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
-      }
+      "dev": true
     },
     "ember-cli-eslint": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/ember-cli-eslint/-/ember-cli-eslint-4.0.0.tgz",
       "integrity": "sha512-g/Hij6jMd/fYEVQgNNaaSeUjH2d4/FpzOfdpAYX5t1bv9PCMdM4TgGSNYUtmqu/Pd2aqPn38+gF8jXnGJO5Npw==",
-      "dev": true,
-      "requires": {
-        "broccoli-lint-eslint": "4.1.0",
-        "ember-cli-version-checker": "2.1.0",
-        "rsvp": "3.6.2",
-        "walk-sync": "0.3.2"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
-          "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA==",
-          "dev": true
-        },
-        "ajv": {
-          "version": "5.2.3",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
-          "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
-          "dev": true,
-          "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.0.0",
-            "json-schema-traverse": "0.3.1",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
-        "ajv-keywords": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.0.tgz",
-          "integrity": "sha1-opbhf3v658HOT34N5T0pyzIWLfA=",
-          "dev": true
-        },
-        "ansi-escapes": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-          "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
-          "dev": true
-        },
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
-        },
-        "broccoli-lint-eslint": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/broccoli-lint-eslint/-/broccoli-lint-eslint-4.1.0.tgz",
-          "integrity": "sha1-3M+hFQ3GJAfNZv1WphknPFR5oQ4=",
-          "dev": true,
-          "requires": {
-            "aot-test-generators": "0.1.0",
-            "broccoli-concat": "3.2.2",
-            "broccoli-persistent-filter": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
-            "eslint": "4.9.0",
-            "json-stable-stringify": "1.0.1",
-            "lodash.defaultsdeep": "4.6.0",
-            "md5-hex": "2.0.0"
-          }
-        },
-        "chalk": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.2.0.tgz",
-          "integrity": "sha512-0BMM/2hG3ZaoPfR6F+h/oWpZtsh3b/s62TjSM6MGCJWEbJDN1acqCXvyhhZsDSVFklpebUoQ5O1kKC7lOzrn9g==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
-          }
-        },
-        "cli-cursor": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-          "dev": true,
-          "requires": {
-            "restore-cursor": "2.0.0"
-          }
-        },
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "4.1.1",
-            "shebang-command": "1.2.0",
-            "which": "https://registry.npmjs.org/which/-/which-1.3.0.tgz"
-          }
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ember-cli-version-checker": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz",
-          "integrity": "sha1-/HmlYDLzcXz4RK2ny97BoG/ttgQ=",
-          "dev": true,
-          "requires": {
-            "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
-          }
-        },
-        "eslint": {
-          "version": "4.9.0",
-          "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.9.0.tgz",
-          "integrity": "sha1-doedJ0BoJhsZH+Dy9Wx0wvQgjos=",
-          "dev": true,
-          "requires": {
-            "ajv": "5.2.3",
-            "babel-code-frame": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-            "chalk": "2.2.0",
-            "concat-stream": "1.6.0",
-            "cross-spawn": "5.1.0",
-            "debug": "3.1.0",
-            "doctrine": "2.1.0",
-            "eslint-scope": "3.7.1",
-            "espree": "3.5.1",
-            "esquery": "1.0.0",
-            "estraverse": "4.2.0",
-            "esutils": "2.0.2",
-            "file-entry-cache": "2.0.0",
-            "functional-red-black-tree": "1.0.1",
-            "glob": "7.1.2",
-            "globals": "9.18.0",
-            "ignore": "3.3.7",
-            "imurmurhash": "0.1.4",
-            "inquirer": "3.3.0",
-            "is-resolvable": "1.1.0",
-            "js-yaml": "3.10.0",
-            "json-stable-stringify": "1.0.1",
-            "levn": "0.3.0",
-            "lodash": "4.17.4",
-            "minimatch": "3.0.4",
-            "mkdirp": "0.5.1",
-            "natural-compare": "1.4.0",
-            "optionator": "0.8.2",
-            "path-is-inside": "1.0.2",
-            "pluralize": "7.0.0",
-            "progress": "2.0.0",
-            "require-uncached": "1.0.3",
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-            "strip-ansi": "4.0.0",
-            "strip-json-comments": "2.0.1",
-            "table": "4.0.2",
-            "text-table": "0.2.0"
-          },
-          "dependencies": {
-            "doctrine": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-              "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-              "dev": true,
-              "requires": {
-                "esutils": "2.0.2"
-              }
-            },
-            "ignore": {
-              "version": "3.3.7",
-              "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-              "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
-              "dev": true
-            },
-            "is-resolvable": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-              "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
-              "dev": true
-            }
-          }
-        },
-        "espree": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.1.tgz",
-          "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
-          "dev": true,
-          "requires": {
-            "acorn": "5.1.2",
-            "acorn-jsx": "3.0.1"
-          }
-        },
-        "esprima": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-          "dev": true
-        },
-        "external-editor": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
-          "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
-          "dev": true,
-          "requires": {
-            "chardet": "0.4.2",
-            "iconv-lite": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-            "tmp": "0.0.33"
-          }
-        },
-        "inquirer": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-          "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
-          "dev": true,
-          "requires": {
-            "ansi-escapes": "3.0.0",
-            "chalk": "2.2.0",
-            "cli-cursor": "2.1.0",
-            "cli-width": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-            "external-editor": "2.1.0",
-            "figures": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-            "lodash": "4.17.4",
-            "mute-stream": "0.0.7",
-            "run-async": "2.3.0",
-            "rx-lite": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-            "rx-lite-aggregates": "4.0.8",
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "through": "2.3.8"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "js-yaml": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-          "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
-          "dev": true,
-          "requires": {
-            "argparse": "1.0.9",
-            "esprima": "4.0.0"
-          }
-        },
-        "mute-stream": {
-          "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-          "dev": true
-        },
-        "onetime": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "1.1.0"
-          }
-        },
-        "pluralize": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-          "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
-          "dev": true
-        },
-        "progress": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-          "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
-          "dev": true
-        },
-        "restore-cursor": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-          "dev": true,
-          "requires": {
-            "onetime": "2.0.1",
-            "signal-exit": "3.0.2"
-          }
-        },
-        "slice-ansi": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-          "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0"
-          }
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
-        },
-        "table": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-          "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
-          "dev": true,
-          "requires": {
-            "ajv": "5.2.3",
-            "ajv-keywords": "2.1.0",
-            "chalk": "2.2.0",
-            "lodash": "4.17.4",
-            "slice-ansi": "1.0.0",
-            "string-width": "2.1.1"
-          }
-        },
-        "tmp": {
-          "version": "0.0.33",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-          "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "1.0.2"
-          }
-        }
-      }
+      "dev": true
     },
     "ember-cli-get-component-path-option": {
       "version": "1.0.0",
@@ -4001,65 +2652,12 @@
       "resolved": "https://registry.npmjs.org/ember-cli-github-pages/-/ember-cli-github-pages-0.1.2.tgz",
       "integrity": "sha1-g7EdMHhYWVWCumHpBgIgmjfVs0g=",
       "dev": true,
-      "requires": {
-        "ember-cli-babel": "5.2.4",
-        "ember-cli-version-checker": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-        "rsvp": "3.6.2"
-      },
       "dependencies": {
         "babel-core": {
           "version": "5.8.38",
           "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
           "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
-          "dev": true,
-          "requires": {
-            "babel-plugin-constant-folding": "1.0.1",
-            "babel-plugin-dead-code-elimination": "1.0.2",
-            "babel-plugin-eval": "1.0.1",
-            "babel-plugin-inline-environment-variables": "1.0.1",
-            "babel-plugin-jscript": "1.0.4",
-            "babel-plugin-member-expression-literals": "1.0.1",
-            "babel-plugin-property-literals": "1.0.1",
-            "babel-plugin-proto-to-assign": "1.0.4",
-            "babel-plugin-react-constant-elements": "1.0.3",
-            "babel-plugin-react-display-name": "1.0.3",
-            "babel-plugin-remove-console": "1.0.1",
-            "babel-plugin-remove-debugger": "1.0.1",
-            "babel-plugin-runtime": "1.0.7",
-            "babel-plugin-undeclared-variables-check": "1.0.2",
-            "babel-plugin-undefined-to-void": "1.1.6",
-            "babylon": "5.8.38",
-            "bluebird": "2.11.0",
-            "chalk": "1.1.3",
-            "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-            "core-js": "1.2.7",
-            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "detect-indent": "3.0.1",
-            "esutils": "2.0.2",
-            "fs-readdir-recursive": "0.1.2",
-            "globals": "6.4.1",
-            "home-or-tmp": "1.0.0",
-            "is-integer": "1.0.7",
-            "js-tokens": "1.0.1",
-            "json5": "0.4.0",
-            "lodash": "3.10.1",
-            "minimatch": "2.0.10",
-            "output-file-sync": "1.1.2",
-            "path-exists": "1.0.0",
-            "path-is-absolute": "1.0.1",
-            "private": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-            "regenerator": "0.8.40",
-            "regexpu": "1.3.0",
-            "repeating": "1.1.3",
-            "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-            "shebang-regex": "1.0.0",
-            "slash": "1.0.0",
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-            "source-map-support": "0.2.10",
-            "to-fast-properties": "1.0.3",
-            "trim-right": "1.0.1",
-            "try-resolve": "1.0.1"
-          }
+          "dev": true
         },
         "babylon": {
           "version": "5.8.38",
@@ -4068,22 +2666,10 @@
           "dev": true
         },
         "broccoli-babel-transpiler": {
-          "version": "5.7.2",
-          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.2.tgz",
-          "integrity": "sha512-vFQ+aSR9J81fm3MXXQGgDxswYINHl2p5duLvRLVnpmgPDNdpdsa30gh3xnmhzR/GwWFBfUNle7aYxthlgvsN0w==",
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.4.tgz",
+          "integrity": "sha512-gI14Pqc4qbmn5RW4SuAmybLiOoYW59D+HzQyhY6WdaGMAjikKBwJN0p17phyvafQ+kvG0mUiMd83lgHLeATnEA==",
           "dev": true,
-          "requires": {
-            "babel-core": "5.8.38",
-            "broccoli-funnel": "1.2.0",
-            "broccoli-merge-trees": "1.2.4",
-            "broccoli-persistent-filter": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
-            "clone": "0.2.0",
-            "hash-for-dep": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
-            "heimdalljs-logger": "0.1.9",
-            "json-stable-stringify": "1.0.1",
-            "rsvp": "3.6.2",
-            "workerpool": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.0.tgz"
-          },
           "dependencies": {
             "clone": {
               "version": "0.2.0",
@@ -4103,33 +2689,19 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
           "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "4.0.1",
-            "minimist": "1.2.0",
-            "repeating": "1.1.3"
-          }
+          "dev": true
         },
         "ember-cli-babel": {
-          "version": "5.2.4",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz",
-          "integrity": "sha1-XOT0awjtb20h6Hhhn7aJcZ1ujhM=",
-          "dev": true,
-          "requires": {
-            "broccoli-babel-transpiler": "5.7.2",
-            "broccoli-funnel": "1.2.0",
-            "clone": "2.1.1",
-            "ember-cli-version-checker": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-            "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz"
-          }
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.8.tgz",
+          "integrity": "sha512-Mt9OOB5RaZwjde+LYef8EgwNVCAzsYDv4ktshblaXxr4m/Xm5/7/rxEu42RNrYkoy/qWpT9uhaD+JKK4riMf+w==",
+          "dev": true
         },
         "ember-cli-version-checker": {
-          "version": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-          "integrity": "sha512-mu1Apdd19ZuDsy9WAHheFhltaJx+0ardFNM8Hb/AeRO9RokOK/bdUq/Jc1oeg0/Hl18tnxg8STG9TyJ6HgE3+g==",
-          "dev": true,
-          "requires": {
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
-          }
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
+          "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
+          "dev": true
         },
         "globals": {
           "version": "6.4.1",
@@ -4141,11 +2713,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
           "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "1.0.2",
-            "user-home": "1.1.1"
-          }
+          "dev": true
         },
         "js-tokens": {
           "version": "1.0.1",
@@ -4169,10 +2737,7 @@
           "version": "2.0.10",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
+          "dev": true
         },
         "minimist": {
           "version": "1.2.0",
@@ -4184,28 +2749,19 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
           "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
-          "dev": true,
-          "requires": {
-            "is-finite": "1.0.2"
-          }
+          "dev": true
         },
         "source-map-support": {
           "version": "0.2.10",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
           "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
           "dev": true,
-          "requires": {
-            "source-map": "0.1.32"
-          },
           "dependencies": {
             "source-map": {
               "version": "0.1.32",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
               "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
-              "dev": true,
-              "requires": {
-                "amdefine": "1.0.1"
-              }
+              "dev": true
             }
           }
         }
@@ -4214,38 +2770,18 @@
     "ember-cli-htmlbars": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-2.0.1.tgz",
-      "integrity": "sha1-4eMzx+9MxUbGdzSZZUH9lMpEI8o=",
-      "requires": {
-        "broccoli-persistent-filter": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
-        "hash-for-dep": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
-        "json-stable-stringify": "1.0.1",
-        "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
-      }
+      "integrity": "sha1-4eMzx+9MxUbGdzSZZUH9lMpEI8o="
     },
     "ember-cli-htmlbars-inline-precompile": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ember-cli-htmlbars-inline-precompile/-/ember-cli-htmlbars-inline-precompile-1.0.0.tgz",
       "integrity": "sha512-t4o19OSQN1dfla//dqWL1cZM5dLzaVUyZGFVrR+t1uMcP8ovPXF7+nCWFeKjjvQUqI0NVnUG77IC9THHeKpDjw==",
-      "dev": true,
-      "requires": {
-        "babel-plugin-htmlbars-inline-precompile": "0.2.3",
-        "ember-cli-version-checker": "2.1.0",
-        "hash-for-dep": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
-        "heimdalljs-logger": "0.1.9",
-        "silent-error": "1.1.0"
-      },
-      "dependencies": {
-        "ember-cli-version-checker": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz",
-          "integrity": "sha1-/HmlYDLzcXz4RK2ny97BoG/ttgQ=",
-          "dev": true,
-          "requires": {
-            "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
-          }
-        }
-      }
+      "dev": true
+    },
+    "ember-cli-import-polyfill": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-import-polyfill/-/ember-cli-import-polyfill-0.2.0.tgz",
+      "integrity": "sha1-waCKiv+0XJe2dZJicv54z0yhZvI="
     },
     "ember-cli-inject-live-reload": {
       "version": "1.7.0",
@@ -4264,25 +2800,6 @@
       "resolved": "https://registry.npmjs.org/ember-cli-legacy-blueprints/-/ember-cli-legacy-blueprints-0.1.5.tgz",
       "integrity": "sha1-k8FcokLsUQfWKor37DD2rFOPOtk=",
       "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "ember-cli-get-component-path-option": "1.0.0",
-        "ember-cli-get-dependency-depth": "1.0.0",
-        "ember-cli-is-package-missing": "1.0.0",
-        "ember-cli-lodash-subset": "1.0.12",
-        "ember-cli-normalize-entity-name": "1.0.0",
-        "ember-cli-path-utils": "1.0.0",
-        "ember-cli-string-utils": "1.1.0",
-        "ember-cli-test-info": "1.0.0",
-        "ember-cli-valid-component-name": "1.0.0",
-        "ember-cli-version-checker": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-        "ember-router-generator": "1.2.3",
-        "exists-sync": "0.0.3",
-        "fs-extra": "0.24.0",
-        "inflection": "1.12.0",
-        "rsvp": "3.6.2",
-        "silent-error": "1.1.0"
-      },
       "dependencies": {
         "ember-cli-lodash-subset": {
           "version": "1.0.12",
@@ -4291,12 +2808,10 @@
           "dev": true
         },
         "ember-cli-version-checker": {
-          "version": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-          "integrity": "sha512-mu1Apdd19ZuDsy9WAHheFhltaJx+0ardFNM8Hb/AeRO9RokOK/bdUq/Jc1oeg0/Hl18tnxg8STG9TyJ6HgE3+g==",
-          "dev": true,
-          "requires": {
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
-          }
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
+          "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
+          "dev": true
         },
         "exists-sync": {
           "version": "0.0.3",
@@ -4308,13 +2823,7 @@
           "version": "0.24.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.24.0.tgz",
           "integrity": "sha1-1OQ0KpZnXLeEZjOmCZJJMytTmVI=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "path-is-absolute": "1.0.1",
-            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz"
-          }
+          "dev": true
         }
       }
     },
@@ -4328,111 +2837,37 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/ember-cli-moment-shim/-/ember-cli-moment-shim-3.1.0.tgz",
       "integrity": "sha1-7Go5oNy0ut6vbct0psBbC8V29yE=",
-      "requires": {
-        "broccoli-funnel": "1.2.0",
-        "broccoli-merge-trees": "2.0.0",
-        "broccoli-stew": "1.5.0",
-        "chalk": "1.1.3",
-        "ember-cli-babel": "5.2.4",
-        "exists-sync": "0.0.4",
-        "lodash.defaults": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-        "moment": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
-        "moment-timezone": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.14.tgz"
-      },
+      "dev": true,
       "dependencies": {
         "babel-core": {
           "version": "5.8.38",
           "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
           "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
-          "requires": {
-            "babel-plugin-constant-folding": "1.0.1",
-            "babel-plugin-dead-code-elimination": "1.0.2",
-            "babel-plugin-eval": "1.0.1",
-            "babel-plugin-inline-environment-variables": "1.0.1",
-            "babel-plugin-jscript": "1.0.4",
-            "babel-plugin-member-expression-literals": "1.0.1",
-            "babel-plugin-property-literals": "1.0.1",
-            "babel-plugin-proto-to-assign": "1.0.4",
-            "babel-plugin-react-constant-elements": "1.0.3",
-            "babel-plugin-react-display-name": "1.0.3",
-            "babel-plugin-remove-console": "1.0.1",
-            "babel-plugin-remove-debugger": "1.0.1",
-            "babel-plugin-runtime": "1.0.7",
-            "babel-plugin-undeclared-variables-check": "1.0.2",
-            "babel-plugin-undefined-to-void": "1.1.6",
-            "babylon": "5.8.38",
-            "bluebird": "2.11.0",
-            "chalk": "1.1.3",
-            "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-            "core-js": "1.2.7",
-            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "detect-indent": "3.0.1",
-            "esutils": "2.0.2",
-            "fs-readdir-recursive": "0.1.2",
-            "globals": "6.4.1",
-            "home-or-tmp": "1.0.0",
-            "is-integer": "1.0.7",
-            "js-tokens": "1.0.1",
-            "json5": "0.4.0",
-            "lodash": "3.10.1",
-            "minimatch": "2.0.10",
-            "output-file-sync": "1.1.2",
-            "path-exists": "1.0.0",
-            "path-is-absolute": "1.0.1",
-            "private": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-            "regenerator": "0.8.40",
-            "regexpu": "1.3.0",
-            "repeating": "1.1.3",
-            "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-            "shebang-regex": "1.0.0",
-            "slash": "1.0.0",
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-            "source-map-support": "0.2.10",
-            "to-fast-properties": "1.0.3",
-            "trim-right": "1.0.1",
-            "try-resolve": "1.0.1"
-          }
+          "dev": true
         },
         "babylon": {
           "version": "5.8.38",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
-          "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0="
+          "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0=",
+          "dev": true
         },
         "broccoli-babel-transpiler": {
-          "version": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.2.tgz",
-          "integrity": "sha512-vFQ+aSR9J81fm3MXXQGgDxswYINHl2p5duLvRLVnpmgPDNdpdsa30gh3xnmhzR/GwWFBfUNle7aYxthlgvsN0w==",
-          "requires": {
-            "babel-core": "5.8.38",
-            "broccoli-funnel": "1.2.0",
-            "broccoli-merge-trees": "1.2.4",
-            "broccoli-persistent-filter": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
-            "clone": "0.2.0",
-            "hash-for-dep": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
-            "heimdalljs-logger": "0.1.9",
-            "json-stable-stringify": "1.0.1",
-            "rsvp": "3.6.2",
-            "workerpool": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.0.tgz"
-          },
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.4.tgz",
+          "integrity": "sha512-gI14Pqc4qbmn5RW4SuAmybLiOoYW59D+HzQyhY6WdaGMAjikKBwJN0p17phyvafQ+kvG0mUiMd83lgHLeATnEA==",
+          "dev": true,
           "dependencies": {
             "broccoli-merge-trees": {
               "version": "1.2.4",
               "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz",
               "integrity": "sha1-oAFRm7UGfwZYnZGvopQkRaLQ/bU=",
-              "requires": {
-                "broccoli-plugin": "1.3.0",
-                "can-symlink": "1.0.0",
-                "fast-ordered-set": "1.0.3",
-                "fs-tree-diff": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.7.tgz",
-                "heimdalljs": "0.2.5",
-                "heimdalljs-logger": "0.1.9",
-                "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-                "symlink-or-copy": "1.1.8"
-              }
+              "dev": true
             },
             "clone": {
               "version": "0.2.0",
               "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-              "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8="
+              "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+              "dev": true
             }
           }
         },
@@ -4440,114 +2875,91 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.0.tgz",
           "integrity": "sha1-EK6kbdXOvMi499WlTwqEpPC7kLk=",
-          "requires": {
-            "broccoli-plugin": "1.3.0",
-            "merge-trees": "1.0.1"
-          }
+          "dev": true
         },
         "core-js": {
           "version": "1.2.7",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+          "dev": true
         },
         "detect-indent": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
           "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
-          "requires": {
-            "get-stdin": "4.0.1",
-            "minimist": "1.2.0",
-            "repeating": "1.1.3"
-          }
+          "dev": true
         },
         "ember-cli-babel": {
-          "version": "5.2.4",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz",
-          "integrity": "sha1-XOT0awjtb20h6Hhhn7aJcZ1ujhM=",
-          "requires": {
-            "broccoli-babel-transpiler": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.2.tgz",
-            "broccoli-funnel": "1.2.0",
-            "clone": "2.1.1",
-            "ember-cli-version-checker": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-            "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz"
-          }
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.8.tgz",
+          "integrity": "sha512-Mt9OOB5RaZwjde+LYef8EgwNVCAzsYDv4ktshblaXxr4m/Xm5/7/rxEu42RNrYkoy/qWpT9uhaD+JKK4riMf+w==",
+          "dev": true
         },
         "ember-cli-version-checker": {
-          "version": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-          "integrity": "sha512-mu1Apdd19ZuDsy9WAHheFhltaJx+0ardFNM8Hb/AeRO9RokOK/bdUq/Jc1oeg0/Hl18tnxg8STG9TyJ6HgE3+g==",
-          "requires": {
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
-          }
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
+          "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
+          "dev": true
         },
         "globals": {
           "version": "6.4.1",
           "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
-          "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08="
+          "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08=",
+          "dev": true
         },
         "home-or-tmp": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
           "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
-          "requires": {
-            "os-tmpdir": "1.0.2",
-            "user-home": "1.1.1"
-          }
+          "dev": true
         },
         "js-tokens": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz",
-          "integrity": "sha1-zENaXIuUrRWst5gxQPyAGCyJrq4="
+          "integrity": "sha1-zENaXIuUrRWst5gxQPyAGCyJrq4=",
+          "dev": true
         },
         "json5": {
           "version": "0.4.0",
           "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-          "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
+          "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0=",
+          "dev": true
         },
         "lodash": {
           "version": "3.10.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
-        },
-        "lodash.defaults": {
-          "version": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-          "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+          "dev": true
         },
         "minimatch": {
           "version": "2.0.10",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
+          "dev": true
         },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
         },
         "repeating": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
           "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
-          "requires": {
-            "is-finite": "1.0.2"
-          }
+          "dev": true
         },
         "source-map-support": {
           "version": "0.2.10",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
           "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
-          "requires": {
-            "source-map": "0.1.32"
-          },
+          "dev": true,
           "dependencies": {
             "source-map": {
               "version": "0.1.32",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
               "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
-              "requires": {
-                "amdefine": "1.0.1"
-              }
+              "dev": true
             }
           }
         }
@@ -4557,10 +2969,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ember-cli-normalize-entity-name/-/ember-cli-normalize-entity-name-1.0.0.tgz",
       "integrity": "sha1-CxT3vLxZmqEXtf3cgeT9A8S61bc=",
-      "dev": true,
-      "requires": {
-        "silent-error": "1.1.0"
-      }
+      "dev": true
     },
     "ember-cli-path-utils": {
       "version": "1.0.0",
@@ -4573,16 +2982,6 @@
       "resolved": "https://registry.npmjs.org/ember-cli-preprocess-registry/-/ember-cli-preprocess-registry-3.1.1.tgz",
       "integrity": "sha1-OEVsIcTStklFhQz57Gjba6dpKIo=",
       "dev": true,
-      "requires": {
-        "broccoli-clean-css": "1.1.0",
-        "broccoli-funnel": "1.2.0",
-        "broccoli-merge-trees": "1.2.4",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-        "ember-cli-lodash-subset": "1.0.12",
-        "exists-sync": "0.0.3",
-        "process-relative-require": "1.0.0",
-        "silent-error": "1.1.0"
-      },
       "dependencies": {
         "ember-cli-lodash-subset": {
           "version": "1.0.12",
@@ -4599,52 +2998,28 @@
       }
     },
     "ember-cli-qunit": {
-      "version": "https://registry.npmjs.org/ember-cli-qunit/-/ember-cli-qunit-4.3.0.tgz",
-      "integrity": "sha512-ClGZldPjHYIftEB80MPvdRdXhAo5QiJHzpO6nTsXC640hFoEtkvyRloKvHSnhR4UH31btMnA29ALAjpoRlufwA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ember-cli-qunit/-/ember-cli-qunit-4.3.2.tgz",
+      "integrity": "sha1-z9ia07DbwoqcIiPVMrUu6t58YCw=",
       "dev": true,
-      "requires": {
-        "ember-cli-babel": "6.12.0",
-        "ember-qunit": "https://registry.npmjs.org/ember-qunit/-/ember-qunit-3.3.0.tgz"
-      },
       "dependencies": {
         "amd-name-resolver": {
           "version": "0.0.7",
           "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-0.0.7.tgz",
           "integrity": "sha1-gUMBrf6KLxCfboTV6TUZbvtmlhU=",
-          "dev": true,
-          "requires": {
-            "ensure-posix-path": "1.0.2"
-          }
+          "dev": true
         },
         "babel-plugin-ember-modules-api-polyfill": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.3.0.tgz",
           "integrity": "sha512-cv5ZimF5X52uW7Ul83UUxtsFZE6rZYkMv6qWnAeiDLT1/KtpVrTkJpwzDlvJ/FhKJZ43ih4GbFbhuhBKKT7vIw==",
-          "dev": true,
-          "requires": {
-            "ember-rfc176-data": "0.3.1"
-          }
+          "dev": true
         },
         "ember-cli-babel": {
           "version": "6.12.0",
           "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.12.0.tgz",
           "integrity": "sha512-LMwZ3Xf3Q3jQUXaJtLLJsbbhRZRNv/iea64lZ8OgqZp1fh66CSXfmqV3L9QSuYQKPDNqFiu2v6IpOT08C6GU6w==",
-          "dev": true,
-          "requires": {
-            "amd-name-resolver": "0.0.7",
-            "babel-plugin-debug-macros": "0.1.11",
-            "babel-plugin-ember-modules-api-polyfill": "2.3.0",
-            "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-            "babel-polyfill": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
-            "babel-preset-env": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
-            "broccoli-babel-transpiler": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.1.2.tgz",
-            "broccoli-debug": "https://registry.npmjs.org/broccoli-debug/-/broccoli-debug-0.6.4.tgz",
-            "broccoli-funnel": "1.2.0",
-            "broccoli-source": "1.1.0",
-            "clone": "2.1.1",
-            "ember-cli-version-checker": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz",
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
-          }
+          "dev": true
         },
         "ember-rfc176-data": {
           "version": "0.3.1",
@@ -4655,47 +3030,21 @@
       }
     },
     "ember-cli-sass": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-sass/-/ember-cli-sass-6.2.0.tgz",
-      "integrity": "sha1-4fgSiWeOHiLZz52/f6LedqDemi8=",
-      "requires": {
-        "broccoli-funnel": "1.2.0",
-        "broccoli-merge-trees": "1.2.4",
-        "broccoli-sass-source-maps": "https://registry.npmjs.org/broccoli-sass-source-maps/-/broccoli-sass-source-maps-2.2.0.tgz",
-        "ember-cli-version-checker": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-        "merge": "1.2.0"
-      },
-      "dependencies": {
-        "ember-cli-version-checker": {
-          "version": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-          "integrity": "sha512-mu1Apdd19ZuDsy9WAHheFhltaJx+0ardFNM8Hb/AeRO9RokOK/bdUq/Jc1oeg0/Hl18tnxg8STG9TyJ6HgE3+g==",
-          "requires": {
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
-          }
-        }
-      }
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/ember-cli-sass/-/ember-cli-sass-7.1.7.tgz",
+      "integrity": "sha512-pbqj4/O9WtXQFeFSJkt04yozePl7ksa39veSDIZwPMCAgGnfD0MEXFrn6spprN2YSrFZM0GsUtk/jwYh8x+Qow=="
     },
     "ember-cli-shims": {
-      "version": "https://registry.npmjs.org/ember-cli-shims/-/ember-cli-shims-1.2.0.tgz",
-      "integrity": "sha512-eqoRtBl4i27uyIvopQqJxWNy8PFCDoePWf6oqf+ICR75I1fx3jTvgatCpUUL5E44DENwyDYWgoIqL/KAO+UFwg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-shims/-/ember-cli-shims-1.2.0.tgz",
+      "integrity": "sha1-D1Ov8Kq4C18p2jqXMbrFYWndlB8=",
       "dev": true,
-      "requires": {
-        "broccoli-file-creator": "https://registry.npmjs.org/broccoli-file-creator/-/broccoli-file-creator-1.1.1.tgz",
-        "broccoli-merge-trees": "2.0.0",
-        "ember-cli-version-checker": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz",
-        "ember-rfc176-data": "0.3.1",
-        "silent-error": "1.1.0"
-      },
       "dependencies": {
         "broccoli-merge-trees": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.0.tgz",
           "integrity": "sha1-EK6kbdXOvMi499WlTwqEpPC7kLk=",
-          "dev": true,
-          "requires": {
-            "broccoli-plugin": "1.3.0",
-            "merge-trees": "1.0.1"
-          }
+          "dev": true
         },
         "ember-rfc176-data": {
           "version": "0.3.1",
@@ -4709,81 +3058,47 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ember-cli-sri/-/ember-cli-sri-2.1.1.tgz",
       "integrity": "sha1-lxYgk0pLkYPPeSPMA+F4uDqpB/0=",
-      "dev": true,
-      "requires": {
-        "broccoli-sri-hash": "2.1.2"
-      }
+      "dev": true
     },
     "ember-cli-string-helpers": {
-      "version": "https://registry.npmjs.org/ember-cli-string-helpers/-/ember-cli-string-helpers-1.6.0.tgz",
-      "integrity": "sha512-3FogmXKY/NbZ35NIPsE7uca1A5pRjbgRUPmFtgXhcW6Qewx81VsKOG3yCjwe40MeIS0+vg0QT5MYAU4vrlBMFg==",
-      "dev": true,
-      "requires": {
-        "broccoli-funnel": "1.2.0",
-        "ember-cli-babel": "6.6.0"
-      }
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-string-helpers/-/ember-cli-string-helpers-1.8.0.tgz",
+      "integrity": "sha1-SAAiEdMGZIx4RjD+6Z+ydidH0ww=",
+      "dev": true
     },
     "ember-cli-string-utils": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/ember-cli-string-utils/-/ember-cli-string-utils-1.1.0.tgz",
-      "integrity": "sha1-ObZ3/CgF9VFzc1N2/O8njqpEUqE=",
-      "dev": true
+      "integrity": "sha1-ObZ3/CgF9VFzc1N2/O8njqpEUqE="
     },
     "ember-cli-test-info": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ember-cli-test-info/-/ember-cli-test-info-1.0.0.tgz",
-      "integrity": "sha1-7U6WDySel1I8+JHkrtIHLOhFd7Q=",
-      "dev": true,
-      "requires": {
-        "ember-cli-string-utils": "1.1.0"
-      }
+      "integrity": "sha1-7U6WDySel1I8+JHkrtIHLOhFd7Q="
     },
     "ember-cli-test-loader": {
-      "version": "https://registry.npmjs.org/ember-cli-test-loader/-/ember-cli-test-loader-2.2.0.tgz",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-test-loader/-/ember-cli-test-loader-2.2.0.tgz",
       "integrity": "sha512-mlSXX9SciIRwGkFTX6XGyJYp4ry6oCFZRxh5jJ7VH8UXLTNx2ZACtDTwaWtNhYrWXgKyiDUvmD8enD56aePWRA==",
       "dev": true,
-      "requires": {
-        "ember-cli-babel": "6.12.0"
-      },
       "dependencies": {
         "amd-name-resolver": {
           "version": "0.0.7",
           "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-0.0.7.tgz",
           "integrity": "sha1-gUMBrf6KLxCfboTV6TUZbvtmlhU=",
-          "dev": true,
-          "requires": {
-            "ensure-posix-path": "1.0.2"
-          }
+          "dev": true
         },
         "babel-plugin-ember-modules-api-polyfill": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.3.0.tgz",
           "integrity": "sha512-cv5ZimF5X52uW7Ul83UUxtsFZE6rZYkMv6qWnAeiDLT1/KtpVrTkJpwzDlvJ/FhKJZ43ih4GbFbhuhBKKT7vIw==",
-          "dev": true,
-          "requires": {
-            "ember-rfc176-data": "0.3.1"
-          }
+          "dev": true
         },
         "ember-cli-babel": {
           "version": "6.12.0",
           "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.12.0.tgz",
           "integrity": "sha512-LMwZ3Xf3Q3jQUXaJtLLJsbbhRZRNv/iea64lZ8OgqZp1fh66CSXfmqV3L9QSuYQKPDNqFiu2v6IpOT08C6GU6w==",
-          "dev": true,
-          "requires": {
-            "amd-name-resolver": "0.0.7",
-            "babel-plugin-debug-macros": "0.1.11",
-            "babel-plugin-ember-modules-api-polyfill": "2.3.0",
-            "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-            "babel-polyfill": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
-            "babel-preset-env": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
-            "broccoli-babel-transpiler": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.1.2.tgz",
-            "broccoli-debug": "https://registry.npmjs.org/broccoli-debug/-/broccoli-debug-0.6.4.tgz",
-            "broccoli-funnel": "1.2.0",
-            "broccoli-source": "1.1.0",
-            "clone": "2.1.1",
-            "ember-cli-version-checker": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz",
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
-          }
+          "dev": true
         },
         "ember-rfc176-data": {
           "version": "0.3.1",
@@ -4794,66 +3109,39 @@
       }
     },
     "ember-cli-uglify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-uglify/-/ember-cli-uglify-2.0.0.tgz",
-      "integrity": "sha1-sJZyfX0XGKzJv+XRvIHOJsr99so=",
-      "dev": true,
-      "requires": {
-        "broccoli-uglify-sourcemap": "https://registry.npmjs.org/broccoli-uglify-sourcemap/-/broccoli-uglify-sourcemap-2.0.2.tgz",
-        "lodash.defaultsdeep": "4.6.0"
-      }
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-uglify/-/ember-cli-uglify-2.1.0.tgz",
+      "integrity": "sha512-lDzdAUfhGx5AMBsgyR54ibENVp/LRQuHNWNaP2SDjkAXDyuYFgW0iXIAfGbxF6+nYaesJ9Tr9AKOfTPlwxZDSg==",
+      "dev": true
     },
     "ember-cli-valid-component-name": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ember-cli-valid-component-name/-/ember-cli-valid-component-name-1.0.0.tgz",
       "integrity": "sha1-cVUM44fgIzBl8wswsVEKot++h+8=",
-      "dev": true,
-      "requires": {
-        "silent-error": "1.1.0"
-      }
+      "dev": true
     },
     "ember-cli-version-checker": {
-      "version": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz",
-      "integrity": "sha512-ssiNyVTp+PphroFum8guHX9py4xU1PCxkRYgb25NxumgjpKTPjhkgTfpRRKXlIQe+/wVMmhf+Uv6w9vSLZKWKQ==",
-      "requires": {
-        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-        "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
-      }
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz",
+      "integrity": "sha512-ssiNyVTp+PphroFum8guHX9py4xU1PCxkRYgb25NxumgjpKTPjhkgTfpRRKXlIQe+/wVMmhf+Uv6w9vSLZKWKQ=="
     },
     "ember-code-snippet": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ember-code-snippet/-/ember-code-snippet-2.0.0.tgz",
       "integrity": "sha1-eeAGyYJBHcfrIb9aUf62bNNtfzs=",
       "dev": true,
-      "requires": {
-        "broccoli-flatiron": "0.0.0",
-        "broccoli-merge-trees": "1.2.4",
-        "broccoli-static-compiler": "0.1.4",
-        "broccoli-writer": "0.1.1",
-        "es6-promise": "1.0.0",
-        "glob": "4.5.3"
-      },
       "dependencies": {
         "glob": {
           "version": "4.5.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
           "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
-          "dev": true,
-          "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "2.0.10",
-            "once": "1.4.0"
-          }
+          "dev": true
         },
         "minimatch": {
           "version": "2.0.10",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
+          "dev": true
         }
       }
     },
@@ -4861,56 +3149,27 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ember-composable-helpers/-/ember-composable-helpers-2.1.0.tgz",
       "integrity": "sha512-H6KCyB/BzjR18MxQFcQQR5MDRmawCmCCZKHQTEpAwhs5wCDhnMMLUGINan+sY4NRPrStfpUlMoGg9fsksN2wJA==",
-      "dev": true,
-      "requires": {
-        "broccoli-funnel": "1.2.0",
-        "ember-cli-babel": "6.6.0"
-      }
+      "dev": true
     },
     "ember-concurrency": {
-      "version": "https://registry.npmjs.org/ember-concurrency/-/ember-concurrency-0.8.13.tgz",
-      "integrity": "sha512-6cO9+LYhZgAK9HGYRbcVdIoVSz34Y+WrQ/ntDfSujpah0VK6AvE3z97zW2Sowl9s2hlJK+G+Yww74inBCMSjrQ==",
-      "requires": {
-        "babel-core": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
-        "ember-cli-babel": "6.12.0",
-        "ember-maybe-import-regenerator": "0.1.6"
-      },
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/ember-concurrency/-/ember-concurrency-0.8.17.tgz",
+      "integrity": "sha1-vkepA0Lxlg9PVyhML+X3ziOWFCo=",
       "dependencies": {
         "amd-name-resolver": {
           "version": "0.0.7",
           "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-0.0.7.tgz",
-          "integrity": "sha1-gUMBrf6KLxCfboTV6TUZbvtmlhU=",
-          "requires": {
-            "ensure-posix-path": "1.0.2"
-          }
+          "integrity": "sha1-gUMBrf6KLxCfboTV6TUZbvtmlhU="
         },
         "babel-plugin-ember-modules-api-polyfill": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.3.0.tgz",
-          "integrity": "sha512-cv5ZimF5X52uW7Ul83UUxtsFZE6rZYkMv6qWnAeiDLT1/KtpVrTkJpwzDlvJ/FhKJZ43ih4GbFbhuhBKKT7vIw==",
-          "requires": {
-            "ember-rfc176-data": "0.3.1"
-          }
+          "integrity": "sha512-cv5ZimF5X52uW7Ul83UUxtsFZE6rZYkMv6qWnAeiDLT1/KtpVrTkJpwzDlvJ/FhKJZ43ih4GbFbhuhBKKT7vIw=="
         },
         "ember-cli-babel": {
           "version": "6.12.0",
           "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.12.0.tgz",
-          "integrity": "sha512-LMwZ3Xf3Q3jQUXaJtLLJsbbhRZRNv/iea64lZ8OgqZp1fh66CSXfmqV3L9QSuYQKPDNqFiu2v6IpOT08C6GU6w==",
-          "requires": {
-            "amd-name-resolver": "0.0.7",
-            "babel-plugin-debug-macros": "0.1.11",
-            "babel-plugin-ember-modules-api-polyfill": "2.3.0",
-            "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-            "babel-polyfill": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
-            "babel-preset-env": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
-            "broccoli-babel-transpiler": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.1.2.tgz",
-            "broccoli-debug": "https://registry.npmjs.org/broccoli-debug/-/broccoli-debug-0.6.4.tgz",
-            "broccoli-funnel": "1.2.0",
-            "broccoli-source": "1.1.0",
-            "clone": "2.1.1",
-            "ember-cli-version-checker": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz",
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
-          }
+          "integrity": "sha512-LMwZ3Xf3Q3jQUXaJtLLJsbbhRZRNv/iea64lZ8OgqZp1fh66CSXfmqV3L9QSuYQKPDNqFiu2v6IpOT08C6GU6w=="
         },
         "ember-rfc176-data": {
           "version": "0.3.1",
@@ -4930,293 +3189,12 @@
       "resolved": "https://registry.npmjs.org/ember-disable-proxy-controllers/-/ember-disable-proxy-controllers-1.0.1.tgz",
       "integrity": "sha1-ElTu7AugJcJOuejaYRr6ezh1QoE=",
       "dev": true,
-      "requires": {
-        "ember-cli-babel": "5.2.4"
-      },
       "dependencies": {
         "babel-core": {
           "version": "5.8.38",
           "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
           "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
-          "dev": true,
-          "requires": {
-            "babel-plugin-constant-folding": "1.0.1",
-            "babel-plugin-dead-code-elimination": "1.0.2",
-            "babel-plugin-eval": "1.0.1",
-            "babel-plugin-inline-environment-variables": "1.0.1",
-            "babel-plugin-jscript": "1.0.4",
-            "babel-plugin-member-expression-literals": "1.0.1",
-            "babel-plugin-property-literals": "1.0.1",
-            "babel-plugin-proto-to-assign": "1.0.4",
-            "babel-plugin-react-constant-elements": "1.0.3",
-            "babel-plugin-react-display-name": "1.0.3",
-            "babel-plugin-remove-console": "1.0.1",
-            "babel-plugin-remove-debugger": "1.0.1",
-            "babel-plugin-runtime": "1.0.7",
-            "babel-plugin-undeclared-variables-check": "1.0.2",
-            "babel-plugin-undefined-to-void": "1.1.6",
-            "babylon": "5.8.38",
-            "bluebird": "2.11.0",
-            "chalk": "1.1.3",
-            "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-            "core-js": "1.2.7",
-            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "detect-indent": "3.0.1",
-            "esutils": "2.0.2",
-            "fs-readdir-recursive": "0.1.2",
-            "globals": "6.4.1",
-            "home-or-tmp": "1.0.0",
-            "is-integer": "1.0.7",
-            "js-tokens": "1.0.1",
-            "json5": "0.4.0",
-            "lodash": "3.10.1",
-            "minimatch": "2.0.10",
-            "output-file-sync": "1.1.2",
-            "path-exists": "1.0.0",
-            "path-is-absolute": "1.0.1",
-            "private": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-            "regenerator": "0.8.40",
-            "regexpu": "1.3.0",
-            "repeating": "1.1.3",
-            "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-            "shebang-regex": "1.0.0",
-            "slash": "1.0.0",
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-            "source-map-support": "0.2.10",
-            "to-fast-properties": "1.0.3",
-            "trim-right": "1.0.1",
-            "try-resolve": "1.0.1"
-          }
-        },
-        "babylon": {
-          "version": "5.8.38",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
-          "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0=",
           "dev": true
-        },
-        "broccoli-babel-transpiler": {
-          "version": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.2.tgz",
-          "integrity": "sha512-vFQ+aSR9J81fm3MXXQGgDxswYINHl2p5duLvRLVnpmgPDNdpdsa30gh3xnmhzR/GwWFBfUNle7aYxthlgvsN0w==",
-          "dev": true,
-          "requires": {
-            "babel-core": "5.8.38",
-            "broccoli-funnel": "1.2.0",
-            "broccoli-merge-trees": "1.2.4",
-            "broccoli-persistent-filter": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
-            "clone": "0.2.0",
-            "hash-for-dep": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
-            "heimdalljs-logger": "0.1.9",
-            "json-stable-stringify": "1.0.1",
-            "rsvp": "3.6.2",
-            "workerpool": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.0.tgz"
-          },
-          "dependencies": {
-            "clone": {
-              "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-              "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
-              "dev": true
-            }
-          }
-        },
-        "core-js": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
-          "dev": true
-        },
-        "detect-indent": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-          "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "4.0.1",
-            "minimist": "1.2.0",
-            "repeating": "1.1.3"
-          }
-        },
-        "ember-cli-babel": {
-          "version": "5.2.4",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz",
-          "integrity": "sha1-XOT0awjtb20h6Hhhn7aJcZ1ujhM=",
-          "dev": true,
-          "requires": {
-            "broccoli-babel-transpiler": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.2.tgz",
-            "broccoli-funnel": "1.2.0",
-            "clone": "2.1.1",
-            "ember-cli-version-checker": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-            "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz"
-          }
-        },
-        "ember-cli-version-checker": {
-          "version": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-          "integrity": "sha512-mu1Apdd19ZuDsy9WAHheFhltaJx+0ardFNM8Hb/AeRO9RokOK/bdUq/Jc1oeg0/Hl18tnxg8STG9TyJ6HgE3+g==",
-          "dev": true,
-          "requires": {
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
-          }
-        },
-        "globals": {
-          "version": "6.4.1",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
-          "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08=",
-          "dev": true
-        },
-        "home-or-tmp": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-          "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "1.0.2",
-            "user-home": "1.1.1"
-          }
-        },
-        "js-tokens": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz",
-          "integrity": "sha1-zENaXIuUrRWst5gxQPyAGCyJrq4=",
-          "dev": true
-        },
-        "json5": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-          "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "2.0.10",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
-        "repeating": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-          "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
-          "dev": true,
-          "requires": {
-            "is-finite": "1.0.2"
-          }
-        },
-        "source-map-support": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
-          "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
-          "dev": true,
-          "requires": {
-            "source-map": "0.1.32"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.1.32",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-              "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
-              "dev": true,
-              "requires": {
-                "amdefine": "1.0.1"
-              }
-            }
-          }
-        }
-      }
-    },
-    "ember-export-application-global": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ember-export-application-global/-/ember-export-application-global-2.0.0.tgz",
-      "integrity": "sha1-jW12GayKGj+MQwA1Sesh6+1oW9I=",
-      "dev": true,
-      "requires": {
-        "ember-cli-babel": "6.6.0"
-      }
-    },
-    "ember-factory-for-polyfill": {
-      "version": "https://registry.npmjs.org/ember-factory-for-polyfill/-/ember-factory-for-polyfill-1.3.1.tgz",
-      "integrity": "sha512-y3iG2iCzH96lZMTWQw6LWNLAfOmDC4pXKbZP6FxG8lt7GGaNFkZjwsf+Z5GAe7kxfD7UG4lVkF7x37K82rySGA==",
-      "dev": true,
-      "requires": {
-        "ember-cli-version-checker": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz"
-      }
-    },
-    "ember-getowner-polyfill": {
-      "version": "https://registry.npmjs.org/ember-getowner-polyfill/-/ember-getowner-polyfill-1.2.5.tgz",
-      "integrity": "sha512-o8zK9AOfuW7CYS8CGKQG6miMj6I+sp/PeJmgfJyOoqT/24JYh4F0m8Fml4+Oljhc5BFihApnzGv++3FmL2CZwA==",
-      "dev": true,
-      "requires": {
-        "ember-cli-babel": "5.2.4",
-        "ember-cli-version-checker": "1.3.1",
-        "ember-factory-for-polyfill": "https://registry.npmjs.org/ember-factory-for-polyfill/-/ember-factory-for-polyfill-1.3.1.tgz"
-      },
-      "dependencies": {
-        "babel-core": {
-          "version": "5.8.38",
-          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
-          "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
-          "dev": true,
-          "requires": {
-            "babel-plugin-constant-folding": "1.0.1",
-            "babel-plugin-dead-code-elimination": "1.0.2",
-            "babel-plugin-eval": "1.0.1",
-            "babel-plugin-inline-environment-variables": "1.0.1",
-            "babel-plugin-jscript": "1.0.4",
-            "babel-plugin-member-expression-literals": "1.0.1",
-            "babel-plugin-property-literals": "1.0.1",
-            "babel-plugin-proto-to-assign": "1.0.4",
-            "babel-plugin-react-constant-elements": "1.0.3",
-            "babel-plugin-react-display-name": "1.0.3",
-            "babel-plugin-remove-console": "1.0.1",
-            "babel-plugin-remove-debugger": "1.0.1",
-            "babel-plugin-runtime": "1.0.7",
-            "babel-plugin-undeclared-variables-check": "1.0.2",
-            "babel-plugin-undefined-to-void": "1.1.6",
-            "babylon": "5.8.38",
-            "bluebird": "2.11.0",
-            "chalk": "1.1.3",
-            "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-            "core-js": "1.2.7",
-            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "detect-indent": "3.0.1",
-            "esutils": "2.0.2",
-            "fs-readdir-recursive": "0.1.2",
-            "globals": "6.4.1",
-            "home-or-tmp": "1.0.0",
-            "is-integer": "1.0.7",
-            "js-tokens": "1.0.1",
-            "json5": "0.4.0",
-            "lodash": "3.10.1",
-            "minimatch": "2.0.10",
-            "output-file-sync": "1.1.2",
-            "path-exists": "1.0.0",
-            "path-is-absolute": "1.0.1",
-            "private": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-            "regenerator": "0.8.40",
-            "regexpu": "1.3.0",
-            "repeating": "1.1.3",
-            "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-            "shebang-regex": "1.0.0",
-            "slash": "1.0.0",
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-            "source-map-support": "0.2.10",
-            "to-fast-properties": "1.0.3",
-            "trim-right": "1.0.1",
-            "try-resolve": "1.0.1"
-          }
         },
         "babylon": {
           "version": "5.8.38",
@@ -5229,18 +3207,6 @@
           "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.4.tgz",
           "integrity": "sha512-gI14Pqc4qbmn5RW4SuAmybLiOoYW59D+HzQyhY6WdaGMAjikKBwJN0p17phyvafQ+kvG0mUiMd83lgHLeATnEA==",
           "dev": true,
-          "requires": {
-            "babel-core": "5.8.38",
-            "broccoli-funnel": "1.2.0",
-            "broccoli-merge-trees": "1.2.4",
-            "broccoli-persistent-filter": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
-            "clone": "0.2.0",
-            "hash-for-dep": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
-            "heimdalljs-logger": "0.1.9",
-            "json-stable-stringify": "1.0.1",
-            "rsvp": "3.6.2",
-            "workerpool": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.0.tgz"
-          },
           "dependencies": {
             "clone": {
               "version": "0.2.0",
@@ -5260,34 +3226,19 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
           "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "4.0.1",
-            "minimist": "1.2.0",
-            "repeating": "1.1.3"
-          }
+          "dev": true
         },
         "ember-cli-babel": {
-          "version": "5.2.4",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz",
-          "integrity": "sha1-XOT0awjtb20h6Hhhn7aJcZ1ujhM=",
-          "dev": true,
-          "requires": {
-            "broccoli-babel-transpiler": "5.7.4",
-            "broccoli-funnel": "1.2.0",
-            "clone": "2.1.1",
-            "ember-cli-version-checker": "1.3.1",
-            "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz"
-          }
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.8.tgz",
+          "integrity": "sha512-Mt9OOB5RaZwjde+LYef8EgwNVCAzsYDv4ktshblaXxr4m/Xm5/7/rxEu42RNrYkoy/qWpT9uhaD+JKK4riMf+w==",
+          "dev": true
         },
         "ember-cli-version-checker": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
           "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
-          "dev": true,
-          "requires": {
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
-          }
+          "dev": true
         },
         "globals": {
           "version": "6.4.1",
@@ -5299,11 +3250,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
           "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "1.0.2",
-            "user-home": "1.1.1"
-          }
+          "dev": true
         },
         "js-tokens": {
           "version": "1.0.1",
@@ -5327,10 +3274,7 @@
           "version": "2.0.10",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
+          "dev": true
         },
         "minimist": {
           "version": "1.2.0",
@@ -5342,105 +3286,51 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
           "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
-          "dev": true,
-          "requires": {
-            "is-finite": "1.0.2"
-          }
+          "dev": true
         },
         "source-map-support": {
           "version": "0.2.10",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
           "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
           "dev": true,
-          "requires": {
-            "source-map": "0.1.32"
-          },
           "dependencies": {
             "source-map": {
               "version": "0.1.32",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
               "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
-              "dev": true,
-              "requires": {
-                "amdefine": "1.0.1"
-              }
+              "dev": true
             }
           }
         }
       }
+    },
+    "ember-export-application-global": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ember-export-application-global/-/ember-export-application-global-2.0.0.tgz",
+      "integrity": "sha1-jW12GayKGj+MQwA1Sesh6+1oW9I=",
+      "dev": true
+    },
+    "ember-factory-for-polyfill": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/ember-factory-for-polyfill/-/ember-factory-for-polyfill-1.3.1.tgz",
+      "integrity": "sha512-y3iG2iCzH96lZMTWQw6LWNLAfOmDC4pXKbZP6FxG8lt7GGaNFkZjwsf+Z5GAe7kxfD7UG4lVkF7x37K82rySGA=="
+    },
+    "ember-getowner-polyfill": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ember-getowner-polyfill/-/ember-getowner-polyfill-2.2.0.tgz",
+      "integrity": "sha512-rwGMJgbGzxIAiWYjdpAh04Abvt0s3HuS/VjHzUFhVyVg2pzAuz45B9AzOxYXzkp88vFC7FPaiA4kE8NxNk4A4Q=="
     },
     "ember-inline-svg": {
       "version": "0.1.11",
       "resolved": "https://registry.npmjs.org/ember-inline-svg/-/ember-inline-svg-0.1.11.tgz",
       "integrity": "sha1-u1ryTO8ds6suGorsVDvuJio2jDc=",
       "dev": true,
-      "requires": {
-        "broccoli-caching-writer": "3.0.3",
-        "broccoli-flatiron": "0.0.0",
-        "broccoli-funnel": "1.2.0",
-        "broccoli-merge-trees": "2.0.0",
-        "ember-cli-babel": "5.2.4",
-        "merge": "1.2.0",
-        "mkdirp": "0.5.1",
-        "promise-map-series": "0.2.3",
-        "rsvp": "3.6.2",
-        "svgo": "0.6.6",
-        "walk-sync": "0.3.2"
-      },
       "dependencies": {
         "babel-core": {
           "version": "5.8.38",
           "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
           "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
-          "dev": true,
-          "requires": {
-            "babel-plugin-constant-folding": "1.0.1",
-            "babel-plugin-dead-code-elimination": "1.0.2",
-            "babel-plugin-eval": "1.0.1",
-            "babel-plugin-inline-environment-variables": "1.0.1",
-            "babel-plugin-jscript": "1.0.4",
-            "babel-plugin-member-expression-literals": "1.0.1",
-            "babel-plugin-property-literals": "1.0.1",
-            "babel-plugin-proto-to-assign": "1.0.4",
-            "babel-plugin-react-constant-elements": "1.0.3",
-            "babel-plugin-react-display-name": "1.0.3",
-            "babel-plugin-remove-console": "1.0.1",
-            "babel-plugin-remove-debugger": "1.0.1",
-            "babel-plugin-runtime": "1.0.7",
-            "babel-plugin-undeclared-variables-check": "1.0.2",
-            "babel-plugin-undefined-to-void": "1.1.6",
-            "babylon": "5.8.38",
-            "bluebird": "2.11.0",
-            "chalk": "1.1.3",
-            "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-            "core-js": "1.2.7",
-            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "detect-indent": "3.0.1",
-            "esutils": "2.0.2",
-            "fs-readdir-recursive": "0.1.2",
-            "globals": "6.4.1",
-            "home-or-tmp": "1.0.0",
-            "is-integer": "1.0.7",
-            "js-tokens": "1.0.1",
-            "json5": "0.4.0",
-            "lodash": "3.10.1",
-            "minimatch": "2.0.10",
-            "output-file-sync": "1.1.2",
-            "path-exists": "1.0.0",
-            "path-is-absolute": "1.0.1",
-            "private": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-            "regenerator": "0.8.40",
-            "regexpu": "1.3.0",
-            "repeating": "1.1.3",
-            "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-            "shebang-regex": "1.0.0",
-            "slash": "1.0.0",
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-            "source-map-support": "0.2.10",
-            "to-fast-properties": "1.0.3",
-            "trim-right": "1.0.1",
-            "try-resolve": "1.0.1"
-          }
+          "dev": true
         },
         "babylon": {
           "version": "5.8.38",
@@ -5449,37 +3339,16 @@
           "dev": true
         },
         "broccoli-babel-transpiler": {
-          "version": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.2.tgz",
-          "integrity": "sha512-vFQ+aSR9J81fm3MXXQGgDxswYINHl2p5duLvRLVnpmgPDNdpdsa30gh3xnmhzR/GwWFBfUNle7aYxthlgvsN0w==",
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.4.tgz",
+          "integrity": "sha512-gI14Pqc4qbmn5RW4SuAmybLiOoYW59D+HzQyhY6WdaGMAjikKBwJN0p17phyvafQ+kvG0mUiMd83lgHLeATnEA==",
           "dev": true,
-          "requires": {
-            "babel-core": "5.8.38",
-            "broccoli-funnel": "1.2.0",
-            "broccoli-merge-trees": "1.2.4",
-            "broccoli-persistent-filter": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
-            "clone": "0.2.0",
-            "hash-for-dep": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
-            "heimdalljs-logger": "0.1.9",
-            "json-stable-stringify": "1.0.1",
-            "rsvp": "3.6.2",
-            "workerpool": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.0.tgz"
-          },
           "dependencies": {
             "broccoli-merge-trees": {
               "version": "1.2.4",
               "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz",
               "integrity": "sha1-oAFRm7UGfwZYnZGvopQkRaLQ/bU=",
-              "dev": true,
-              "requires": {
-                "broccoli-plugin": "1.3.0",
-                "can-symlink": "1.0.0",
-                "fast-ordered-set": "1.0.3",
-                "fs-tree-diff": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.7.tgz",
-                "heimdalljs": "0.2.5",
-                "heimdalljs-logger": "0.1.9",
-                "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-                "symlink-or-copy": "1.1.8"
-              }
+              "dev": true
             },
             "clone": {
               "version": "0.2.0",
@@ -5493,11 +3362,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.0.tgz",
           "integrity": "sha1-EK6kbdXOvMi499WlTwqEpPC7kLk=",
-          "dev": true,
-          "requires": {
-            "broccoli-plugin": "1.3.0",
-            "merge-trees": "1.0.1"
-          }
+          "dev": true
         },
         "core-js": {
           "version": "1.2.7",
@@ -5509,33 +3374,19 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
           "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "4.0.1",
-            "minimist": "1.2.0",
-            "repeating": "1.1.3"
-          }
+          "dev": true
         },
         "ember-cli-babel": {
-          "version": "5.2.4",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz",
-          "integrity": "sha1-XOT0awjtb20h6Hhhn7aJcZ1ujhM=",
-          "dev": true,
-          "requires": {
-            "broccoli-babel-transpiler": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.2.tgz",
-            "broccoli-funnel": "1.2.0",
-            "clone": "2.1.1",
-            "ember-cli-version-checker": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-            "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz"
-          }
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.8.tgz",
+          "integrity": "sha512-Mt9OOB5RaZwjde+LYef8EgwNVCAzsYDv4ktshblaXxr4m/Xm5/7/rxEu42RNrYkoy/qWpT9uhaD+JKK4riMf+w==",
+          "dev": true
         },
         "ember-cli-version-checker": {
-          "version": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-          "integrity": "sha512-mu1Apdd19ZuDsy9WAHheFhltaJx+0ardFNM8Hb/AeRO9RokOK/bdUq/Jc1oeg0/Hl18tnxg8STG9TyJ6HgE3+g==",
-          "dev": true,
-          "requires": {
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
-          }
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
+          "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
+          "dev": true
         },
         "globals": {
           "version": "6.4.1",
@@ -5547,11 +3398,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
           "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "1.0.2",
-            "user-home": "1.1.1"
-          }
+          "dev": true
         },
         "js-tokens": {
           "version": "1.0.1",
@@ -5575,10 +3422,7 @@
           "version": "2.0.10",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
+          "dev": true
         },
         "minimist": {
           "version": "1.2.0",
@@ -5590,28 +3434,19 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
           "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
-          "dev": true,
-          "requires": {
-            "is-finite": "1.0.2"
-          }
+          "dev": true
         },
         "source-map-support": {
           "version": "0.2.10",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
           "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
           "dev": true,
-          "requires": {
-            "source-map": "0.1.32"
-          },
           "dependencies": {
             "source-map": {
               "version": "0.1.32",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
               "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
-              "dev": true,
-              "requires": {
-                "amdefine": "1.0.1"
-              }
+              "dev": true
             }
           }
         }
@@ -5622,63 +3457,12 @@
       "resolved": "https://registry.npmjs.org/ember-interpolate-helper/-/ember-interpolate-helper-1.0.0.tgz",
       "integrity": "sha1-uh2nBtnlQK1UgBSZMtLXO0x4e8M=",
       "dev": true,
-      "requires": {
-        "ember-cli-babel": "5.2.4"
-      },
       "dependencies": {
         "babel-core": {
           "version": "5.8.38",
           "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
           "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
-          "dev": true,
-          "requires": {
-            "babel-plugin-constant-folding": "1.0.1",
-            "babel-plugin-dead-code-elimination": "1.0.2",
-            "babel-plugin-eval": "1.0.1",
-            "babel-plugin-inline-environment-variables": "1.0.1",
-            "babel-plugin-jscript": "1.0.4",
-            "babel-plugin-member-expression-literals": "1.0.1",
-            "babel-plugin-property-literals": "1.0.1",
-            "babel-plugin-proto-to-assign": "1.0.4",
-            "babel-plugin-react-constant-elements": "1.0.3",
-            "babel-plugin-react-display-name": "1.0.3",
-            "babel-plugin-remove-console": "1.0.1",
-            "babel-plugin-remove-debugger": "1.0.1",
-            "babel-plugin-runtime": "1.0.7",
-            "babel-plugin-undeclared-variables-check": "1.0.2",
-            "babel-plugin-undefined-to-void": "1.1.6",
-            "babylon": "5.8.38",
-            "bluebird": "2.11.0",
-            "chalk": "1.1.3",
-            "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-            "core-js": "1.2.7",
-            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "detect-indent": "3.0.1",
-            "esutils": "2.0.2",
-            "fs-readdir-recursive": "0.1.2",
-            "globals": "6.4.1",
-            "home-or-tmp": "1.0.0",
-            "is-integer": "1.0.7",
-            "js-tokens": "1.0.1",
-            "json5": "0.4.0",
-            "lodash": "3.10.1",
-            "minimatch": "2.0.10",
-            "output-file-sync": "1.1.2",
-            "path-exists": "1.0.0",
-            "path-is-absolute": "1.0.1",
-            "private": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-            "regenerator": "0.8.40",
-            "regexpu": "1.3.0",
-            "repeating": "1.1.3",
-            "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-            "shebang-regex": "1.0.0",
-            "slash": "1.0.0",
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-            "source-map-support": "0.2.10",
-            "to-fast-properties": "1.0.3",
-            "trim-right": "1.0.1",
-            "try-resolve": "1.0.1"
-          }
+          "dev": true
         },
         "babylon": {
           "version": "5.8.38",
@@ -5687,21 +3471,10 @@
           "dev": true
         },
         "broccoli-babel-transpiler": {
-          "version": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.2.tgz",
-          "integrity": "sha512-vFQ+aSR9J81fm3MXXQGgDxswYINHl2p5duLvRLVnpmgPDNdpdsa30gh3xnmhzR/GwWFBfUNle7aYxthlgvsN0w==",
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.4.tgz",
+          "integrity": "sha512-gI14Pqc4qbmn5RW4SuAmybLiOoYW59D+HzQyhY6WdaGMAjikKBwJN0p17phyvafQ+kvG0mUiMd83lgHLeATnEA==",
           "dev": true,
-          "requires": {
-            "babel-core": "5.8.38",
-            "broccoli-funnel": "1.2.0",
-            "broccoli-merge-trees": "1.2.4",
-            "broccoli-persistent-filter": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
-            "clone": "0.2.0",
-            "hash-for-dep": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
-            "heimdalljs-logger": "0.1.9",
-            "json-stable-stringify": "1.0.1",
-            "rsvp": "3.6.2",
-            "workerpool": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.0.tgz"
-          },
           "dependencies": {
             "clone": {
               "version": "0.2.0",
@@ -5721,33 +3494,19 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
           "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "4.0.1",
-            "minimist": "1.2.0",
-            "repeating": "1.1.3"
-          }
+          "dev": true
         },
         "ember-cli-babel": {
-          "version": "5.2.4",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz",
-          "integrity": "sha1-XOT0awjtb20h6Hhhn7aJcZ1ujhM=",
-          "dev": true,
-          "requires": {
-            "broccoli-babel-transpiler": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.2.tgz",
-            "broccoli-funnel": "1.2.0",
-            "clone": "2.1.1",
-            "ember-cli-version-checker": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-            "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz"
-          }
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.8.tgz",
+          "integrity": "sha512-Mt9OOB5RaZwjde+LYef8EgwNVCAzsYDv4ktshblaXxr4m/Xm5/7/rxEu42RNrYkoy/qWpT9uhaD+JKK4riMf+w==",
+          "dev": true
         },
         "ember-cli-version-checker": {
-          "version": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-          "integrity": "sha512-mu1Apdd19ZuDsy9WAHheFhltaJx+0ardFNM8Hb/AeRO9RokOK/bdUq/Jc1oeg0/Hl18tnxg8STG9TyJ6HgE3+g==",
-          "dev": true,
-          "requires": {
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
-          }
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
+          "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
+          "dev": true
         },
         "globals": {
           "version": "6.4.1",
@@ -5759,11 +3518,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
           "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "1.0.2",
-            "user-home": "1.1.1"
-          }
+          "dev": true
         },
         "js-tokens": {
           "version": "1.0.1",
@@ -5787,10 +3542,7 @@
           "version": "2.0.10",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
+          "dev": true
         },
         "minimist": {
           "version": "1.2.0",
@@ -5802,28 +3554,19 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
           "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
-          "dev": true,
-          "requires": {
-            "is-finite": "1.0.2"
-          }
+          "dev": true
         },
         "source-map-support": {
           "version": "0.2.10",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
           "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
           "dev": true,
-          "requires": {
-            "source-map": "0.1.32"
-          },
           "dependencies": {
             "source-map": {
               "version": "0.1.32",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
               "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
-              "dev": true,
-              "requires": {
-                "amdefine": "1.0.1"
-              }
+              "dev": true
             }
           }
         }
@@ -5834,63 +3577,12 @@
       "resolved": "https://registry.npmjs.org/ember-keyboard/-/ember-keyboard-2.1.10.tgz",
       "integrity": "sha1-uIWlcqVgxSudUqEFPFnVSNQQD74=",
       "dev": true,
-      "requires": {
-        "ember-cli-babel": "5.2.4"
-      },
       "dependencies": {
         "babel-core": {
           "version": "5.8.38",
           "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
           "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
-          "dev": true,
-          "requires": {
-            "babel-plugin-constant-folding": "1.0.1",
-            "babel-plugin-dead-code-elimination": "1.0.2",
-            "babel-plugin-eval": "1.0.1",
-            "babel-plugin-inline-environment-variables": "1.0.1",
-            "babel-plugin-jscript": "1.0.4",
-            "babel-plugin-member-expression-literals": "1.0.1",
-            "babel-plugin-property-literals": "1.0.1",
-            "babel-plugin-proto-to-assign": "1.0.4",
-            "babel-plugin-react-constant-elements": "1.0.3",
-            "babel-plugin-react-display-name": "1.0.3",
-            "babel-plugin-remove-console": "1.0.1",
-            "babel-plugin-remove-debugger": "1.0.1",
-            "babel-plugin-runtime": "1.0.7",
-            "babel-plugin-undeclared-variables-check": "1.0.2",
-            "babel-plugin-undefined-to-void": "1.1.6",
-            "babylon": "5.8.38",
-            "bluebird": "2.11.0",
-            "chalk": "1.1.3",
-            "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-            "core-js": "1.2.7",
-            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "detect-indent": "3.0.1",
-            "esutils": "2.0.2",
-            "fs-readdir-recursive": "0.1.2",
-            "globals": "6.4.1",
-            "home-or-tmp": "1.0.0",
-            "is-integer": "1.0.7",
-            "js-tokens": "1.0.1",
-            "json5": "0.4.0",
-            "lodash": "3.10.1",
-            "minimatch": "2.0.10",
-            "output-file-sync": "1.1.2",
-            "path-exists": "1.0.0",
-            "path-is-absolute": "1.0.1",
-            "private": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-            "regenerator": "0.8.40",
-            "regexpu": "1.3.0",
-            "repeating": "1.1.3",
-            "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-            "shebang-regex": "1.0.0",
-            "slash": "1.0.0",
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-            "source-map-support": "0.2.10",
-            "to-fast-properties": "1.0.3",
-            "trim-right": "1.0.1",
-            "try-resolve": "1.0.1"
-          }
+          "dev": true
         },
         "babylon": {
           "version": "5.8.38",
@@ -5899,21 +3591,10 @@
           "dev": true
         },
         "broccoli-babel-transpiler": {
-          "version": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.2.tgz",
-          "integrity": "sha512-vFQ+aSR9J81fm3MXXQGgDxswYINHl2p5duLvRLVnpmgPDNdpdsa30gh3xnmhzR/GwWFBfUNle7aYxthlgvsN0w==",
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.4.tgz",
+          "integrity": "sha512-gI14Pqc4qbmn5RW4SuAmybLiOoYW59D+HzQyhY6WdaGMAjikKBwJN0p17phyvafQ+kvG0mUiMd83lgHLeATnEA==",
           "dev": true,
-          "requires": {
-            "babel-core": "5.8.38",
-            "broccoli-funnel": "1.2.0",
-            "broccoli-merge-trees": "1.2.4",
-            "broccoli-persistent-filter": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
-            "clone": "0.2.0",
-            "hash-for-dep": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
-            "heimdalljs-logger": "0.1.9",
-            "json-stable-stringify": "1.0.1",
-            "rsvp": "3.6.2",
-            "workerpool": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.0.tgz"
-          },
           "dependencies": {
             "clone": {
               "version": "0.2.0",
@@ -5933,33 +3614,19 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
           "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "4.0.1",
-            "minimist": "1.2.0",
-            "repeating": "1.1.3"
-          }
+          "dev": true
         },
         "ember-cli-babel": {
-          "version": "5.2.4",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz",
-          "integrity": "sha1-XOT0awjtb20h6Hhhn7aJcZ1ujhM=",
-          "dev": true,
-          "requires": {
-            "broccoli-babel-transpiler": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.2.tgz",
-            "broccoli-funnel": "1.2.0",
-            "clone": "2.1.1",
-            "ember-cli-version-checker": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-            "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz"
-          }
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.8.tgz",
+          "integrity": "sha512-Mt9OOB5RaZwjde+LYef8EgwNVCAzsYDv4ktshblaXxr4m/Xm5/7/rxEu42RNrYkoy/qWpT9uhaD+JKK4riMf+w==",
+          "dev": true
         },
         "ember-cli-version-checker": {
-          "version": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-          "integrity": "sha512-mu1Apdd19ZuDsy9WAHheFhltaJx+0ardFNM8Hb/AeRO9RokOK/bdUq/Jc1oeg0/Hl18tnxg8STG9TyJ6HgE3+g==",
-          "dev": true,
-          "requires": {
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
-          }
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
+          "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
+          "dev": true
         },
         "globals": {
           "version": "6.4.1",
@@ -5971,11 +3638,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
           "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "1.0.2",
-            "user-home": "1.1.1"
-          }
+          "dev": true
         },
         "js-tokens": {
           "version": "1.0.1",
@@ -5999,10 +3662,7 @@
           "version": "2.0.10",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
+          "dev": true
         },
         "minimist": {
           "version": "1.2.0",
@@ -6014,28 +3674,19 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
           "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
-          "dev": true,
-          "requires": {
-            "is-finite": "1.0.2"
-          }
+          "dev": true
         },
         "source-map-support": {
           "version": "0.2.10",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
           "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
           "dev": true,
-          "requires": {
-            "source-map": "0.1.32"
-          },
           "dependencies": {
             "source-map": {
               "version": "0.1.32",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
               "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
-              "dev": true,
-              "requires": {
-                "amdefine": "1.0.1"
-              }
+              "dev": true
             }
           }
         }
@@ -6045,215 +3696,17 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ember-load-initializers/-/ember-load-initializers-1.0.0.tgz",
       "integrity": "sha1-SRnq8G9t/sp+E0Yz2MBabJkh5uc=",
-      "dev": true,
-      "requires": {
-        "ember-cli-babel": "6.6.0"
-      }
+      "dev": true
     },
     "ember-macro-helpers": {
-      "version": "https://registry.npmjs.org/ember-macro-helpers/-/ember-macro-helpers-0.4.0.tgz",
-      "integrity": "sha512-i7hXEbePns8ZNxvv/UoId4GpzXGTc7JRHLvnrHHjEegSdVOzk4BCxCTaJWAs6W2dJSzQ1Sc+q7WeeJrCbXJI1A==",
-      "requires": {
-        "ember-cli-babel": "5.2.4"
-      },
-      "dependencies": {
-        "babel-core": {
-          "version": "5.8.38",
-          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
-          "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
-          "requires": {
-            "babel-plugin-constant-folding": "1.0.1",
-            "babel-plugin-dead-code-elimination": "1.0.2",
-            "babel-plugin-eval": "1.0.1",
-            "babel-plugin-inline-environment-variables": "1.0.1",
-            "babel-plugin-jscript": "1.0.4",
-            "babel-plugin-member-expression-literals": "1.0.1",
-            "babel-plugin-property-literals": "1.0.1",
-            "babel-plugin-proto-to-assign": "1.0.4",
-            "babel-plugin-react-constant-elements": "1.0.3",
-            "babel-plugin-react-display-name": "1.0.3",
-            "babel-plugin-remove-console": "1.0.1",
-            "babel-plugin-remove-debugger": "1.0.1",
-            "babel-plugin-runtime": "1.0.7",
-            "babel-plugin-undeclared-variables-check": "1.0.2",
-            "babel-plugin-undefined-to-void": "1.1.6",
-            "babylon": "5.8.38",
-            "bluebird": "2.11.0",
-            "chalk": "1.1.3",
-            "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-            "core-js": "1.2.7",
-            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "detect-indent": "3.0.1",
-            "esutils": "2.0.2",
-            "fs-readdir-recursive": "0.1.2",
-            "globals": "6.4.1",
-            "home-or-tmp": "1.0.0",
-            "is-integer": "1.0.7",
-            "js-tokens": "1.0.1",
-            "json5": "0.4.0",
-            "lodash": "3.10.1",
-            "minimatch": "2.0.10",
-            "output-file-sync": "1.1.2",
-            "path-exists": "1.0.0",
-            "path-is-absolute": "1.0.1",
-            "private": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-            "regenerator": "0.8.40",
-            "regexpu": "1.3.0",
-            "repeating": "1.1.3",
-            "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-            "shebang-regex": "1.0.0",
-            "slash": "1.0.0",
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-            "source-map-support": "0.2.10",
-            "to-fast-properties": "1.0.3",
-            "trim-right": "1.0.1",
-            "try-resolve": "1.0.1"
-          }
-        },
-        "babylon": {
-          "version": "5.8.38",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
-          "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0="
-        },
-        "broccoli-babel-transpiler": {
-          "version": "5.7.4",
-          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.4.tgz",
-          "integrity": "sha512-gI14Pqc4qbmn5RW4SuAmybLiOoYW59D+HzQyhY6WdaGMAjikKBwJN0p17phyvafQ+kvG0mUiMd83lgHLeATnEA==",
-          "requires": {
-            "babel-core": "5.8.38",
-            "broccoli-funnel": "1.2.0",
-            "broccoli-merge-trees": "1.2.4",
-            "broccoli-persistent-filter": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
-            "clone": "0.2.0",
-            "hash-for-dep": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
-            "heimdalljs-logger": "0.1.9",
-            "json-stable-stringify": "1.0.1",
-            "rsvp": "3.6.2",
-            "workerpool": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.0.tgz"
-          },
-          "dependencies": {
-            "clone": {
-              "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-              "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8="
-            }
-          }
-        },
-        "core-js": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-        },
-        "detect-indent": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-          "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
-          "requires": {
-            "get-stdin": "4.0.1",
-            "minimist": "1.2.0",
-            "repeating": "1.1.3"
-          }
-        },
-        "ember-cli-babel": {
-          "version": "5.2.4",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz",
-          "integrity": "sha1-XOT0awjtb20h6Hhhn7aJcZ1ujhM=",
-          "requires": {
-            "broccoli-babel-transpiler": "5.7.4",
-            "broccoli-funnel": "1.2.0",
-            "clone": "2.1.1",
-            "ember-cli-version-checker": "1.3.1",
-            "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz"
-          }
-        },
-        "ember-cli-version-checker": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-          "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
-          "requires": {
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
-          }
-        },
-        "globals": {
-          "version": "6.4.1",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
-          "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08="
-        },
-        "home-or-tmp": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-          "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
-          "requires": {
-            "os-tmpdir": "1.0.2",
-            "user-home": "1.1.1"
-          }
-        },
-        "js-tokens": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz",
-          "integrity": "sha1-zENaXIuUrRWst5gxQPyAGCyJrq4="
-        },
-        "json5": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-          "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
-        },
-        "minimatch": {
-          "version": "2.0.10",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        },
-        "repeating": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-          "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
-          "requires": {
-            "is-finite": "1.0.2"
-          }
-        },
-        "source-map-support": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
-          "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
-          "requires": {
-            "source-map": "0.1.32"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.1.32",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-              "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
-              "requires": {
-                "amdefine": "1.0.1"
-              }
-            }
-          }
-        }
-      }
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/ember-macro-helpers/-/ember-macro-helpers-0.17.0.tgz",
+      "integrity": "sha1-XmSkn0duOMGRav91+UlFVTPNGr4="
     },
     "ember-maybe-import-regenerator": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/ember-maybe-import-regenerator/-/ember-maybe-import-regenerator-0.1.6.tgz",
       "integrity": "sha1-NdQYKK+m1qWbwNo85H80xXPXdso=",
-      "requires": {
-        "broccoli-funnel": "1.2.0",
-        "broccoli-merge-trees": "1.2.4",
-        "ember-cli-babel": "6.6.0",
-        "regenerator-runtime": "0.9.6"
-      },
       "dependencies": {
         "regenerator-runtime": {
           "version": "0.9.6",
@@ -6267,66 +3720,12 @@
       "resolved": "https://registry.npmjs.org/ember-modal-dialog/-/ember-modal-dialog-0.9.0.tgz",
       "integrity": "sha1-4nl3YvE+6lqnFSTB7FFsFQmAsoc=",
       "dev": true,
-      "requires": {
-        "ember-cli-babel": "5.2.4",
-        "ember-cli-htmlbars": "1.3.4",
-        "ember-cli-version-checker": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-        "ember-wormhole": "0.3.6"
-      },
       "dependencies": {
         "babel-core": {
           "version": "5.8.38",
           "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
           "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
-          "dev": true,
-          "requires": {
-            "babel-plugin-constant-folding": "1.0.1",
-            "babel-plugin-dead-code-elimination": "1.0.2",
-            "babel-plugin-eval": "1.0.1",
-            "babel-plugin-inline-environment-variables": "1.0.1",
-            "babel-plugin-jscript": "1.0.4",
-            "babel-plugin-member-expression-literals": "1.0.1",
-            "babel-plugin-property-literals": "1.0.1",
-            "babel-plugin-proto-to-assign": "1.0.4",
-            "babel-plugin-react-constant-elements": "1.0.3",
-            "babel-plugin-react-display-name": "1.0.3",
-            "babel-plugin-remove-console": "1.0.1",
-            "babel-plugin-remove-debugger": "1.0.1",
-            "babel-plugin-runtime": "1.0.7",
-            "babel-plugin-undeclared-variables-check": "1.0.2",
-            "babel-plugin-undefined-to-void": "1.1.6",
-            "babylon": "5.8.38",
-            "bluebird": "2.11.0",
-            "chalk": "1.1.3",
-            "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-            "core-js": "1.2.7",
-            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "detect-indent": "3.0.1",
-            "esutils": "2.0.2",
-            "fs-readdir-recursive": "0.1.2",
-            "globals": "6.4.1",
-            "home-or-tmp": "1.0.0",
-            "is-integer": "1.0.7",
-            "js-tokens": "1.0.1",
-            "json5": "0.4.0",
-            "lodash": "3.10.1",
-            "minimatch": "2.0.10",
-            "output-file-sync": "1.1.2",
-            "path-exists": "1.0.0",
-            "path-is-absolute": "1.0.1",
-            "private": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-            "regenerator": "0.8.40",
-            "regexpu": "1.3.0",
-            "repeating": "1.1.3",
-            "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-            "shebang-regex": "1.0.0",
-            "slash": "1.0.0",
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-            "source-map-support": "0.2.10",
-            "to-fast-properties": "1.0.3",
-            "trim-right": "1.0.1",
-            "try-resolve": "1.0.1"
-          }
+          "dev": true
         },
         "babylon": {
           "version": "5.8.38",
@@ -6335,21 +3734,10 @@
           "dev": true
         },
         "broccoli-babel-transpiler": {
-          "version": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.2.tgz",
-          "integrity": "sha512-vFQ+aSR9J81fm3MXXQGgDxswYINHl2p5duLvRLVnpmgPDNdpdsa30gh3xnmhzR/GwWFBfUNle7aYxthlgvsN0w==",
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.4.tgz",
+          "integrity": "sha512-gI14Pqc4qbmn5RW4SuAmybLiOoYW59D+HzQyhY6WdaGMAjikKBwJN0p17phyvafQ+kvG0mUiMd83lgHLeATnEA==",
           "dev": true,
-          "requires": {
-            "babel-core": "5.8.38",
-            "broccoli-funnel": "1.2.0",
-            "broccoli-merge-trees": "1.2.4",
-            "broccoli-persistent-filter": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
-            "clone": "0.2.0",
-            "hash-for-dep": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
-            "heimdalljs-logger": "0.1.9",
-            "json-stable-stringify": "1.0.1",
-            "rsvp": "3.6.2",
-            "workerpool": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.0.tgz"
-          },
           "dependencies": {
             "clone": {
               "version": "0.2.0",
@@ -6369,46 +3757,25 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
           "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "4.0.1",
-            "minimist": "1.2.0",
-            "repeating": "1.1.3"
-          }
+          "dev": true
         },
         "ember-cli-babel": {
-          "version": "5.2.4",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz",
-          "integrity": "sha1-XOT0awjtb20h6Hhhn7aJcZ1ujhM=",
-          "dev": true,
-          "requires": {
-            "broccoli-babel-transpiler": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.2.tgz",
-            "broccoli-funnel": "1.2.0",
-            "clone": "2.1.1",
-            "ember-cli-version-checker": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-            "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz"
-          }
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.8.tgz",
+          "integrity": "sha512-Mt9OOB5RaZwjde+LYef8EgwNVCAzsYDv4ktshblaXxr4m/Xm5/7/rxEu42RNrYkoy/qWpT9uhaD+JKK4riMf+w==",
+          "dev": true
         },
         "ember-cli-htmlbars": {
           "version": "1.3.4",
           "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-1.3.4.tgz",
           "integrity": "sha512-5lycG6z35QHr3WZF1OkVvT+N/GGAVuemtM6m8NUgBWoeA2TqOgPFRcI0eRqoLA0HAfe0R2MReKmMI7y1LEM1+w==",
-          "dev": true,
-          "requires": {
-            "broccoli-persistent-filter": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
-            "ember-cli-version-checker": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-            "hash-for-dep": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
-            "json-stable-stringify": "1.0.1",
-            "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
-          }
+          "dev": true
         },
         "ember-cli-version-checker": {
-          "version": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-          "integrity": "sha512-mu1Apdd19ZuDsy9WAHheFhltaJx+0ardFNM8Hb/AeRO9RokOK/bdUq/Jc1oeg0/Hl18tnxg8STG9TyJ6HgE3+g==",
-          "dev": true,
-          "requires": {
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
-          }
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
+          "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
+          "dev": true
         },
         "globals": {
           "version": "6.4.1",
@@ -6420,11 +3787,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
           "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "1.0.2",
-            "user-home": "1.1.1"
-          }
+          "dev": true
         },
         "js-tokens": {
           "version": "1.0.1",
@@ -6448,10 +3811,7 @@
           "version": "2.0.10",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
+          "dev": true
         },
         "minimist": {
           "version": "1.2.0",
@@ -6463,38 +3823,27 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
           "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
-          "dev": true,
-          "requires": {
-            "is-finite": "1.0.2"
-          }
+          "dev": true
         },
         "source-map-support": {
           "version": "0.2.10",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
           "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
           "dev": true,
-          "requires": {
-            "source-map": "0.1.32"
-          },
           "dependencies": {
             "source-map": {
               "version": "0.1.32",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
               "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
-              "dev": true,
-              "requires": {
-                "amdefine": "1.0.1"
-              }
+              "dev": true
             }
           }
         },
         "strip-bom": {
-          "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g==",
-          "dev": true,
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true
         }
       }
     },
@@ -6502,202 +3851,123 @@
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/ember-moment/-/ember-moment-7.3.0.tgz",
       "integrity": "sha1-kOoY0jHYXht15F8Vsn0zuQiq0f0=",
-      "requires": {
-        "ember-cli-babel": "5.2.4",
-        "ember-macro-helpers": "https://registry.npmjs.org/ember-macro-helpers/-/ember-macro-helpers-0.4.0.tgz"
-      },
+      "dev": true,
       "dependencies": {
         "babel-core": {
           "version": "5.8.38",
           "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
           "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
-          "requires": {
-            "babel-plugin-constant-folding": "1.0.1",
-            "babel-plugin-dead-code-elimination": "1.0.2",
-            "babel-plugin-eval": "1.0.1",
-            "babel-plugin-inline-environment-variables": "1.0.1",
-            "babel-plugin-jscript": "1.0.4",
-            "babel-plugin-member-expression-literals": "1.0.1",
-            "babel-plugin-property-literals": "1.0.1",
-            "babel-plugin-proto-to-assign": "1.0.4",
-            "babel-plugin-react-constant-elements": "1.0.3",
-            "babel-plugin-react-display-name": "1.0.3",
-            "babel-plugin-remove-console": "1.0.1",
-            "babel-plugin-remove-debugger": "1.0.1",
-            "babel-plugin-runtime": "1.0.7",
-            "babel-plugin-undeclared-variables-check": "1.0.2",
-            "babel-plugin-undefined-to-void": "1.1.6",
-            "babylon": "5.8.38",
-            "bluebird": "2.11.0",
-            "chalk": "1.1.3",
-            "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-            "core-js": "1.2.7",
-            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "detect-indent": "3.0.1",
-            "esutils": "2.0.2",
-            "fs-readdir-recursive": "0.1.2",
-            "globals": "6.4.1",
-            "home-or-tmp": "1.0.0",
-            "is-integer": "1.0.7",
-            "js-tokens": "1.0.1",
-            "json5": "0.4.0",
-            "lodash": "3.10.1",
-            "minimatch": "2.0.10",
-            "output-file-sync": "1.1.2",
-            "path-exists": "1.0.0",
-            "path-is-absolute": "1.0.1",
-            "private": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-            "regenerator": "0.8.40",
-            "regexpu": "1.3.0",
-            "repeating": "1.1.3",
-            "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-            "shebang-regex": "1.0.0",
-            "slash": "1.0.0",
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-            "source-map-support": "0.2.10",
-            "to-fast-properties": "1.0.3",
-            "trim-right": "1.0.1",
-            "try-resolve": "1.0.1"
-          }
+          "dev": true
         },
         "babylon": {
           "version": "5.8.38",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
-          "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0="
+          "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0=",
+          "dev": true
         },
         "broccoli-babel-transpiler": {
-          "version": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.2.tgz",
-          "integrity": "sha512-vFQ+aSR9J81fm3MXXQGgDxswYINHl2p5duLvRLVnpmgPDNdpdsa30gh3xnmhzR/GwWFBfUNle7aYxthlgvsN0w==",
-          "requires": {
-            "babel-core": "5.8.38",
-            "broccoli-funnel": "1.2.0",
-            "broccoli-merge-trees": "1.2.4",
-            "broccoli-persistent-filter": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
-            "clone": "0.2.0",
-            "hash-for-dep": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
-            "heimdalljs-logger": "0.1.9",
-            "json-stable-stringify": "1.0.1",
-            "rsvp": "3.6.2",
-            "workerpool": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.0.tgz"
-          },
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.4.tgz",
+          "integrity": "sha512-gI14Pqc4qbmn5RW4SuAmybLiOoYW59D+HzQyhY6WdaGMAjikKBwJN0p17phyvafQ+kvG0mUiMd83lgHLeATnEA==",
+          "dev": true,
           "dependencies": {
             "clone": {
               "version": "0.2.0",
               "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-              "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8="
+              "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+              "dev": true
             }
           }
         },
         "core-js": {
           "version": "1.2.7",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+          "dev": true
         },
         "detect-indent": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
           "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
-          "requires": {
-            "get-stdin": "4.0.1",
-            "minimist": "1.2.0",
-            "repeating": "1.1.3"
-          }
+          "dev": true
         },
         "ember-cli-babel": {
-          "version": "5.2.4",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz",
-          "integrity": "sha1-XOT0awjtb20h6Hhhn7aJcZ1ujhM=",
-          "requires": {
-            "broccoli-babel-transpiler": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.2.tgz",
-            "broccoli-funnel": "1.2.0",
-            "clone": "2.1.1",
-            "ember-cli-version-checker": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-            "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz"
-          }
-        },
-        "ember-cli-htmlbars": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-1.3.4.tgz",
-          "integrity": "sha512-5lycG6z35QHr3WZF1OkVvT+N/GGAVuemtM6m8NUgBWoeA2TqOgPFRcI0eRqoLA0HAfe0R2MReKmMI7y1LEM1+w==",
-          "requires": {
-            "broccoli-persistent-filter": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
-            "ember-cli-version-checker": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-            "hash-for-dep": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
-            "json-stable-stringify": "1.0.1"
-          }
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.8.tgz",
+          "integrity": "sha512-Mt9OOB5RaZwjde+LYef8EgwNVCAzsYDv4ktshblaXxr4m/Xm5/7/rxEu42RNrYkoy/qWpT9uhaD+JKK4riMf+w==",
+          "dev": true
         },
         "ember-cli-version-checker": {
-          "version": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-          "integrity": "sha512-mu1Apdd19ZuDsy9WAHheFhltaJx+0ardFNM8Hb/AeRO9RokOK/bdUq/Jc1oeg0/Hl18tnxg8STG9TyJ6HgE3+g==",
-          "requires": {
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
-          }
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
+          "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
+          "dev": true
+        },
+        "ember-macro-helpers": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/ember-macro-helpers/-/ember-macro-helpers-0.4.0.tgz",
+          "integrity": "sha1-kUZwABR4/MzMuEgZrKdjDMRFJsg=",
+          "dev": true
         },
         "globals": {
           "version": "6.4.1",
           "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
-          "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08="
+          "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08=",
+          "dev": true
         },
         "home-or-tmp": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
           "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
-          "requires": {
-            "os-tmpdir": "1.0.2",
-            "user-home": "1.1.1"
-          }
+          "dev": true
         },
         "js-tokens": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz",
-          "integrity": "sha1-zENaXIuUrRWst5gxQPyAGCyJrq4="
+          "integrity": "sha1-zENaXIuUrRWst5gxQPyAGCyJrq4=",
+          "dev": true
         },
         "json5": {
           "version": "0.4.0",
           "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-          "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
+          "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0=",
+          "dev": true
         },
         "lodash": {
           "version": "3.10.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+          "dev": true
         },
         "minimatch": {
           "version": "2.0.10",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
+          "dev": true
         },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
         },
         "repeating": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
           "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
-          "requires": {
-            "is-finite": "1.0.2"
-          }
+          "dev": true
         },
         "source-map-support": {
           "version": "0.2.10",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
           "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
-          "requires": {
-            "source-map": "0.1.32"
-          },
+          "dev": true,
           "dependencies": {
             "source-map": {
               "version": "0.1.32",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
               "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
-              "requires": {
-                "amdefine": "1.0.1"
-              }
+              "dev": true
             }
           }
         }
@@ -6707,50 +3977,79 @@
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/ember-native-dom-helpers/-/ember-native-dom-helpers-0.5.4.tgz",
       "integrity": "sha1-C8FQamQ/t63Aq/HQnESnkURZKWs=",
-      "dev": true,
-      "requires": {
-        "broccoli-funnel": "1.2.0",
-        "ember-cli-babel": "6.6.0"
-      }
+      "dev": true
     },
     "ember-power-calendar": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/ember-power-calendar/-/ember-power-calendar-0.5.0.tgz",
       "integrity": "sha1-/T4xLQcl+25iHFlbGQDeqwkS+gE=",
-      "requires": {
-        "ember-assign-helper": "0.1.2",
-        "ember-cli-babel": "6.6.0",
-        "ember-cli-htmlbars": "1.3.4",
-        "ember-cli-moment-shim": "3.1.0",
-        "ember-concurrency": "https://registry.npmjs.org/ember-concurrency/-/ember-concurrency-0.8.13.tgz",
-        "ember-moment": "7.3.0"
-      },
       "dependencies": {
+        "amd-name-resolver": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-0.0.7.tgz",
+          "integrity": "sha1-gUMBrf6KLxCfboTV6TUZbvtmlhU="
+        },
+        "babel-plugin-ember-modules-api-polyfill": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.3.0.tgz",
+          "integrity": "sha512-cv5ZimF5X52uW7Ul83UUxtsFZE6rZYkMv6qWnAeiDLT1/KtpVrTkJpwzDlvJ/FhKJZ43ih4GbFbhuhBKKT7vIw=="
+        },
+        "broccoli-funnel": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.1.tgz",
+          "integrity": "sha512-C8Lnp9TVsSSiZMGEF16C0dCiNg2oJqUKwuZ1K4kVC6qRPG/2Cj/rtB5kRCC9qEbwqhX71bDbfHROx0L3J7zXQg=="
+        },
+        "broccoli-merge-trees": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.0.tgz",
+          "integrity": "sha1-EK6kbdXOvMi499WlTwqEpPC7kLk="
+        },
         "ember-cli-htmlbars": {
           "version": "1.3.4",
           "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-1.3.4.tgz",
-          "integrity": "sha512-5lycG6z35QHr3WZF1OkVvT+N/GGAVuemtM6m8NUgBWoeA2TqOgPFRcI0eRqoLA0HAfe0R2MReKmMI7y1LEM1+w==",
-          "requires": {
-            "broccoli-persistent-filter": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
-            "ember-cli-version-checker": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-            "hash-for-dep": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
-            "json-stable-stringify": "1.0.1",
-            "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
-          }
+          "integrity": "sha512-5lycG6z35QHr3WZF1OkVvT+N/GGAVuemtM6m8NUgBWoeA2TqOgPFRcI0eRqoLA0HAfe0R2MReKmMI7y1LEM1+w=="
+        },
+        "ember-cli-moment-shim": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-moment-shim/-/ember-cli-moment-shim-3.6.0.tgz",
+          "integrity": "sha512-Xb9HRnpH4x9I9un8zpf1rlSzSRpxDvcauA81pisgIfhrIWXsTq5VbCpHWI4ojFKgYTee03+5DtUaWcVT2uT/+g=="
         },
         "ember-cli-version-checker": {
-          "version": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-          "integrity": "sha512-mu1Apdd19ZuDsy9WAHheFhltaJx+0ardFNM8Hb/AeRO9RokOK/bdUq/Jc1oeg0/Hl18tnxg8STG9TyJ6HgE3+g==",
-          "requires": {
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
+          "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI="
+        },
+        "ember-moment": {
+          "version": "7.6.0",
+          "resolved": "https://registry.npmjs.org/ember-moment/-/ember-moment-7.6.0.tgz",
+          "integrity": "sha1-+CvrqBprn06juwrCRjzF0sXL2OY=",
+          "dependencies": {
+            "broccoli-funnel": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+              "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY="
+            },
+            "ember-cli-babel": {
+              "version": "6.12.0",
+              "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.12.0.tgz",
+              "integrity": "sha512-LMwZ3Xf3Q3jQUXaJtLLJsbbhRZRNv/iea64lZ8OgqZp1fh66CSXfmqV3L9QSuYQKPDNqFiu2v6IpOT08C6GU6w=="
+            },
+            "ember-cli-version-checker": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz",
+              "integrity": "sha512-ssiNyVTp+PphroFum8guHX9py4xU1PCxkRYgb25NxumgjpKTPjhkgTfpRRKXlIQe+/wVMmhf+Uv6w9vSLZKWKQ=="
+            }
           }
         },
+        "ember-rfc176-data": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.1.tgz",
+          "integrity": "sha512-u+W5rUvYO7xyKJjiPuCM7bIAvFyPwPTJ66fOZz1xuCv3AyReI9Oev5oOADOO6YJZk+vEn0xWiZ9N6zSf8WU7Fg=="
+        },
         "strip-bom": {
-          "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g==",
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4="
         }
       }
     },
@@ -6759,159 +4058,76 @@
       "resolved": "https://registry.npmjs.org/ember-power-select/-/ember-power-select-1.8.2.tgz",
       "integrity": "sha1-QS9q60i1ky7exynbiqCV8juO7GE=",
       "dev": true,
-      "requires": {
-        "ember-basic-dropdown": "0.32.9",
-        "ember-cli-babel": "6.6.0",
-        "ember-cli-htmlbars": "1.3.4",
-        "ember-concurrency": "https://registry.npmjs.org/ember-concurrency/-/ember-concurrency-0.8.13.tgz",
-        "ember-text-measurer": "0.3.3",
-        "ember-truth-helpers": "1.3.0"
-      },
       "dependencies": {
         "ember-cli-htmlbars": {
           "version": "1.3.4",
           "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-1.3.4.tgz",
           "integrity": "sha512-5lycG6z35QHr3WZF1OkVvT+N/GGAVuemtM6m8NUgBWoeA2TqOgPFRcI0eRqoLA0HAfe0R2MReKmMI7y1LEM1+w==",
-          "dev": true,
-          "requires": {
-            "broccoli-persistent-filter": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
-            "ember-cli-version-checker": "1.3.1",
-            "hash-for-dep": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
-            "json-stable-stringify": "1.0.1",
-            "strip-bom": "2.0.0"
-          },
-          "dependencies": {
-            "ember-cli-version-checker": {
-              "version": "1.3.1",
-              "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-              "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
-              "dev": true,
-              "requires": {
-                "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
-              }
-            },
-            "strip-bom": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-              "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-              "dev": true,
-              "requires": {
-                "is-utf8": "0.2.1"
-              }
-            }
-          }
+          "dev": true
+        },
+        "ember-cli-version-checker": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
+          "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
+          "dev": true
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true
         }
       }
     },
     "ember-qunit": {
-      "version": "https://registry.npmjs.org/ember-qunit/-/ember-qunit-3.3.0.tgz",
-      "integrity": "sha512-Vtiyj0yG0BOpYpjAH5/goS7pFzs3xeQ4QJzoikrtJ/OxB0EWYKyLCXc0Ha54yj+VSRI+fE+tBMPGj9oYAiSi5A==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/ember-qunit/-/ember-qunit-3.4.0.tgz",
+      "integrity": "sha512-muEOJCPnZ21LJAlv8t24iRufZ3Cc+iDZO/ci45efVyVYQOkw+EpyEou2g2bpm+/GDTXi143WBQrdubrGpDHgFQ==",
       "dev": true,
-      "requires": {
-        "@ember/test-helpers": "https://registry.npmjs.org/@ember/test-helpers/-/test-helpers-0.7.13.tgz",
-        "broccoli-funnel": "2.0.1",
-        "broccoli-merge-trees": "2.0.0",
-        "common-tags": "https://registry.npmjs.org/common-tags/-/common-tags-1.7.2.tgz",
-        "ember-cli-babel": "6.6.0",
-        "ember-cli-test-loader": "https://registry.npmjs.org/ember-cli-test-loader/-/ember-cli-test-loader-2.2.0.tgz",
-        "qunit": "https://registry.npmjs.org/qunit/-/qunit-2.5.0.tgz"
-      },
       "dependencies": {
         "broccoli-funnel": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.1.tgz",
           "integrity": "sha512-C8Lnp9TVsSSiZMGEF16C0dCiNg2oJqUKwuZ1K4kVC6qRPG/2Cj/rtB5kRCC9qEbwqhX71bDbfHROx0L3J7zXQg==",
-          "dev": true,
-          "requires": {
-            "array-equal": "1.0.0",
-            "blank-object": "1.0.2",
-            "broccoli-plugin": "1.3.0",
-            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.7.tgz",
-            "heimdalljs": "0.2.5",
-            "minimatch": "3.0.4",
-            "mkdirp": "0.5.1",
-            "path-posix": "1.0.0",
-            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-            "symlink-or-copy": "1.1.8",
-            "walk-sync": "0.3.2"
-          }
+          "dev": true
         },
         "broccoli-merge-trees": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.0.tgz",
           "integrity": "sha1-EK6kbdXOvMi499WlTwqEpPC7kLk=",
-          "dev": true,
-          "requires": {
-            "broccoli-plugin": "1.3.0",
-            "merge-trees": "1.0.1"
-          }
+          "dev": true
         }
       }
     },
     "ember-resolver": {
-      "version": "https://registry.npmjs.org/ember-resolver/-/ember-resolver-4.5.0.tgz",
-      "integrity": "sha512-BX8yvFWIbrh1IVZmpIY/14WUb7nD8tQzT5s0aUG/Nwq2LVqD/uNAEPcsq0XS2gLvKawwDQEQN30ptcvJApQBhA==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/ember-resolver/-/ember-resolver-4.5.5.tgz",
+      "integrity": "sha512-EdzAV/WyddlwnjP7YlXQOHt73ZlJxfYYp0JpZIX27tp5tUFzps3ARnsTiTb8FcLC8BI5ku+ajKLEoDsMjn3BIw==",
       "dev": true,
-      "requires": {
-        "@glimmer/resolver": "https://registry.npmjs.org/@glimmer/resolver/-/resolver-0.4.2.tgz",
-        "babel-plugin-debug-macros": "0.1.11",
-        "broccoli-funnel": "1.2.0",
-        "broccoli-merge-trees": "2.0.0",
-        "ember-cli-babel": "6.12.0",
-        "ember-cli-version-checker": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz",
-        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz"
-      },
       "dependencies": {
         "amd-name-resolver": {
           "version": "0.0.7",
           "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-0.0.7.tgz",
           "integrity": "sha1-gUMBrf6KLxCfboTV6TUZbvtmlhU=",
-          "dev": true,
-          "requires": {
-            "ensure-posix-path": "1.0.2"
-          }
+          "dev": true
         },
         "babel-plugin-ember-modules-api-polyfill": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.3.0.tgz",
           "integrity": "sha512-cv5ZimF5X52uW7Ul83UUxtsFZE6rZYkMv6qWnAeiDLT1/KtpVrTkJpwzDlvJ/FhKJZ43ih4GbFbhuhBKKT7vIw==",
-          "dev": true,
-          "requires": {
-            "ember-rfc176-data": "0.3.1"
-          }
+          "dev": true
         },
         "broccoli-merge-trees": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.0.tgz",
           "integrity": "sha1-EK6kbdXOvMi499WlTwqEpPC7kLk=",
-          "dev": true,
-          "requires": {
-            "broccoli-plugin": "1.3.0",
-            "merge-trees": "1.0.1"
-          }
+          "dev": true
         },
         "ember-cli-babel": {
           "version": "6.12.0",
           "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.12.0.tgz",
           "integrity": "sha512-LMwZ3Xf3Q3jQUXaJtLLJsbbhRZRNv/iea64lZ8OgqZp1fh66CSXfmqV3L9QSuYQKPDNqFiu2v6IpOT08C6GU6w==",
-          "dev": true,
-          "requires": {
-            "amd-name-resolver": "0.0.7",
-            "babel-plugin-debug-macros": "0.1.11",
-            "babel-plugin-ember-modules-api-polyfill": "2.3.0",
-            "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-            "babel-polyfill": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
-            "babel-preset-env": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
-            "broccoli-babel-transpiler": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.1.2.tgz",
-            "broccoli-debug": "https://registry.npmjs.org/broccoli-debug/-/broccoli-debug-0.6.4.tgz",
-            "broccoli-funnel": "1.2.0",
-            "broccoli-source": "1.1.0",
-            "clone": "2.1.1",
-            "ember-cli-version-checker": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz",
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
-          }
+          "dev": true
         },
         "ember-rfc176-data": {
           "version": "0.3.1",
@@ -6922,17 +4138,14 @@
       }
     },
     "ember-responsive": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/ember-responsive/-/ember-responsive-2.0.5.tgz",
-      "integrity": "sha512-Y7Auof3liAZCxhMHkmH3GJXdYwljguUEKAzRKMuoJCXpha0qtUC8IdGCES9Y0pOvMazogQFlacYHiH+3wN7crQ==",
-      "dev": true,
-      "requires": {
-        "ember-cli-babel": "6.6.0",
-        "ember-getowner-polyfill": "https://registry.npmjs.org/ember-getowner-polyfill/-/ember-getowner-polyfill-1.2.5.tgz"
-      }
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/ember-responsive/-/ember-responsive-2.0.8.tgz",
+      "integrity": "sha512-L5SBViR8cY0euQkG/rARMawYK7PXvGdwvmyhjcSA3wUTm49xmUa5z2km/qOekHSFtqVX4GqQCi+RoHPDzWxiGA==",
+      "dev": true
     },
     "ember-rfc176-data": {
-      "version": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.2.7.tgz",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.2.7.tgz",
       "integrity": "sha512-pJE2w+sI22UDsYmudI4nCp3WcImpUzXwe9qHfpOcEu3yM/HD1nGpDRt6kZD0KUnDmqkLeik/nYyzEwN/NU6xxA=="
     },
     "ember-route-action-helper": {
@@ -6940,64 +4153,12 @@
       "resolved": "https://registry.npmjs.org/ember-route-action-helper/-/ember-route-action-helper-2.0.3.tgz",
       "integrity": "sha1-tfhf65D/mvNlZbsVLFuiWbu19ls=",
       "dev": true,
-      "requires": {
-        "ember-cli-babel": "5.2.4",
-        "ember-getowner-polyfill": "https://registry.npmjs.org/ember-getowner-polyfill/-/ember-getowner-polyfill-1.2.5.tgz"
-      },
       "dependencies": {
         "babel-core": {
           "version": "5.8.38",
           "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
           "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
-          "dev": true,
-          "requires": {
-            "babel-plugin-constant-folding": "1.0.1",
-            "babel-plugin-dead-code-elimination": "1.0.2",
-            "babel-plugin-eval": "1.0.1",
-            "babel-plugin-inline-environment-variables": "1.0.1",
-            "babel-plugin-jscript": "1.0.4",
-            "babel-plugin-member-expression-literals": "1.0.1",
-            "babel-plugin-property-literals": "1.0.1",
-            "babel-plugin-proto-to-assign": "1.0.4",
-            "babel-plugin-react-constant-elements": "1.0.3",
-            "babel-plugin-react-display-name": "1.0.3",
-            "babel-plugin-remove-console": "1.0.1",
-            "babel-plugin-remove-debugger": "1.0.1",
-            "babel-plugin-runtime": "1.0.7",
-            "babel-plugin-undeclared-variables-check": "1.0.2",
-            "babel-plugin-undefined-to-void": "1.1.6",
-            "babylon": "5.8.38",
-            "bluebird": "2.11.0",
-            "chalk": "1.1.3",
-            "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-            "core-js": "1.2.7",
-            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "detect-indent": "3.0.1",
-            "esutils": "2.0.2",
-            "fs-readdir-recursive": "0.1.2",
-            "globals": "6.4.1",
-            "home-or-tmp": "1.0.0",
-            "is-integer": "1.0.7",
-            "js-tokens": "1.0.1",
-            "json5": "0.4.0",
-            "lodash": "3.10.1",
-            "minimatch": "2.0.10",
-            "output-file-sync": "1.1.2",
-            "path-exists": "1.0.0",
-            "path-is-absolute": "1.0.1",
-            "private": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-            "regenerator": "0.8.40",
-            "regexpu": "1.3.0",
-            "repeating": "1.1.3",
-            "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-            "shebang-regex": "1.0.0",
-            "slash": "1.0.0",
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-            "source-map-support": "0.2.10",
-            "to-fast-properties": "1.0.3",
-            "trim-right": "1.0.1",
-            "try-resolve": "1.0.1"
-          }
+          "dev": true
         },
         "babylon": {
           "version": "5.8.38",
@@ -7006,21 +4167,10 @@
           "dev": true
         },
         "broccoli-babel-transpiler": {
-          "version": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.2.tgz",
-          "integrity": "sha512-vFQ+aSR9J81fm3MXXQGgDxswYINHl2p5duLvRLVnpmgPDNdpdsa30gh3xnmhzR/GwWFBfUNle7aYxthlgvsN0w==",
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.4.tgz",
+          "integrity": "sha512-gI14Pqc4qbmn5RW4SuAmybLiOoYW59D+HzQyhY6WdaGMAjikKBwJN0p17phyvafQ+kvG0mUiMd83lgHLeATnEA==",
           "dev": true,
-          "requires": {
-            "babel-core": "5.8.38",
-            "broccoli-funnel": "1.2.0",
-            "broccoli-merge-trees": "1.2.4",
-            "broccoli-persistent-filter": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
-            "clone": "0.2.0",
-            "hash-for-dep": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
-            "heimdalljs-logger": "0.1.9",
-            "json-stable-stringify": "1.0.1",
-            "rsvp": "3.6.2",
-            "workerpool": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.0.tgz"
-          },
           "dependencies": {
             "clone": {
               "version": "0.2.0",
@@ -7040,33 +4190,25 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
           "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "4.0.1",
-            "minimist": "1.2.0",
-            "repeating": "1.1.3"
-          }
+          "dev": true
         },
         "ember-cli-babel": {
-          "version": "5.2.4",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz",
-          "integrity": "sha1-XOT0awjtb20h6Hhhn7aJcZ1ujhM=",
-          "dev": true,
-          "requires": {
-            "broccoli-babel-transpiler": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.2.tgz",
-            "broccoli-funnel": "1.2.0",
-            "clone": "2.1.1",
-            "ember-cli-version-checker": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-            "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz"
-          }
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.8.tgz",
+          "integrity": "sha512-Mt9OOB5RaZwjde+LYef8EgwNVCAzsYDv4ktshblaXxr4m/Xm5/7/rxEu42RNrYkoy/qWpT9uhaD+JKK4riMf+w==",
+          "dev": true
         },
         "ember-cli-version-checker": {
-          "version": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-          "integrity": "sha512-mu1Apdd19ZuDsy9WAHheFhltaJx+0ardFNM8Hb/AeRO9RokOK/bdUq/Jc1oeg0/Hl18tnxg8STG9TyJ6HgE3+g==",
-          "dev": true,
-          "requires": {
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
-          }
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
+          "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
+          "dev": true
+        },
+        "ember-getowner-polyfill": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/ember-getowner-polyfill/-/ember-getowner-polyfill-1.2.5.tgz",
+          "integrity": "sha512-o8zK9AOfuW7CYS8CGKQG6miMj6I+sp/PeJmgfJyOoqT/24JYh4F0m8Fml4+Oljhc5BFihApnzGv++3FmL2CZwA==",
+          "dev": true
         },
         "globals": {
           "version": "6.4.1",
@@ -7078,11 +4220,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
           "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "1.0.2",
-            "user-home": "1.1.1"
-          }
+          "dev": true
         },
         "js-tokens": {
           "version": "1.0.1",
@@ -7106,10 +4244,7 @@
           "version": "2.0.10",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
+          "dev": true
         },
         "minimist": {
           "version": "1.2.0",
@@ -7121,28 +4256,19 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
           "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
-          "dev": true,
-          "requires": {
-            "is-finite": "1.0.2"
-          }
+          "dev": true
         },
         "source-map-support": {
           "version": "0.2.10",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
           "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
           "dev": true,
-          "requires": {
-            "source-map": "0.1.32"
-          },
           "dependencies": {
             "source-map": {
               "version": "0.1.32",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
               "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
-              "dev": true,
-              "requires": {
-                "amdefine": "1.0.1"
-              }
+              "dev": true
             }
           }
         }
@@ -7153,9 +4279,6 @@
       "resolved": "https://registry.npmjs.org/ember-router-generator/-/ember-router-generator-1.2.3.tgz",
       "integrity": "sha1-jtLKhv8yM2MSD8FCeBkeno8TFe4=",
       "dev": true,
-      "requires": {
-        "recast": "0.11.23"
-      },
       "dependencies": {
         "esprima": {
           "version": "3.1.3",
@@ -7167,56 +4290,39 @@
           "version": "0.11.23",
           "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
           "integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
-          "dev": true,
-          "requires": {
-            "ast-types": "0.9.6",
-            "esprima": "3.1.3",
-            "private": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
-          }
+          "dev": true
         }
       }
     },
     "ember-source": {
-      "version": "https://registry.npmjs.org/ember-source/-/ember-source-2.16.2.tgz",
-      "integrity": "sha512-zzjqqNs/1N9sn1JFrU7tvtnck8HSAjRglQ2OcbLx99J0XRGe5GIaCGs2xUVeNn2x+28FNNH5O2bTjWT0Ufxcag==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-2.16.4.tgz",
+      "integrity": "sha1-2NcxcwalmmmB4VHVdxyJdpFLdzg=",
       "dev": true,
-      "requires": {
-        "broccoli-funnel": "1.2.0",
-        "broccoli-merge-trees": "2.0.0",
-        "ember-cli-get-component-path-option": "1.0.0",
-        "ember-cli-is-package-missing": "1.0.0",
-        "ember-cli-normalize-entity-name": "1.0.0",
-        "ember-cli-path-utils": "1.0.0",
-        "ember-cli-string-utils": "1.1.0",
-        "ember-cli-test-info": "1.0.0",
-        "ember-cli-valid-component-name": "1.0.0",
-        "ember-cli-version-checker": "1.3.1",
-        "ember-router-generator": "1.2.3",
-        "fs-extra": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
-        "inflection": "1.12.0",
-        "jquery": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
-        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz"
-      },
       "dependencies": {
         "broccoli-merge-trees": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.0.tgz",
           "integrity": "sha1-EK6kbdXOvMi499WlTwqEpPC7kLk=",
-          "dev": true,
-          "requires": {
-            "broccoli-plugin": "1.3.0",
-            "merge-trees": "1.0.1"
-          }
+          "dev": true
         },
         "ember-cli-version-checker": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
           "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
-          "dev": true,
-          "requires": {
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
-          }
+          "dev": true
+        },
+        "fs-extra": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+          "dev": true
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true
         }
       }
     },
@@ -7225,63 +4331,12 @@
       "resolved": "https://registry.npmjs.org/ember-text-measurer/-/ember-text-measurer-0.3.3.tgz",
       "integrity": "sha1-B2KAmnHC4fLmCrAMU8brG2PJ+WM=",
       "dev": true,
-      "requires": {
-        "ember-cli-babel": "5.2.4"
-      },
       "dependencies": {
         "babel-core": {
           "version": "5.8.38",
           "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
           "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
-          "dev": true,
-          "requires": {
-            "babel-plugin-constant-folding": "1.0.1",
-            "babel-plugin-dead-code-elimination": "1.0.2",
-            "babel-plugin-eval": "1.0.1",
-            "babel-plugin-inline-environment-variables": "1.0.1",
-            "babel-plugin-jscript": "1.0.4",
-            "babel-plugin-member-expression-literals": "1.0.1",
-            "babel-plugin-property-literals": "1.0.1",
-            "babel-plugin-proto-to-assign": "1.0.4",
-            "babel-plugin-react-constant-elements": "1.0.3",
-            "babel-plugin-react-display-name": "1.0.3",
-            "babel-plugin-remove-console": "1.0.1",
-            "babel-plugin-remove-debugger": "1.0.1",
-            "babel-plugin-runtime": "1.0.7",
-            "babel-plugin-undeclared-variables-check": "1.0.2",
-            "babel-plugin-undefined-to-void": "1.1.6",
-            "babylon": "5.8.38",
-            "bluebird": "2.11.0",
-            "chalk": "1.1.3",
-            "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-            "core-js": "1.2.7",
-            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "detect-indent": "3.0.1",
-            "esutils": "2.0.2",
-            "fs-readdir-recursive": "0.1.2",
-            "globals": "6.4.1",
-            "home-or-tmp": "1.0.0",
-            "is-integer": "1.0.7",
-            "js-tokens": "1.0.1",
-            "json5": "0.4.0",
-            "lodash": "3.10.1",
-            "minimatch": "2.0.10",
-            "output-file-sync": "1.1.2",
-            "path-exists": "1.0.0",
-            "path-is-absolute": "1.0.1",
-            "private": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-            "regenerator": "0.8.40",
-            "regexpu": "1.3.0",
-            "repeating": "1.1.3",
-            "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-            "shebang-regex": "1.0.0",
-            "slash": "1.0.0",
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-            "source-map-support": "0.2.10",
-            "to-fast-properties": "1.0.3",
-            "trim-right": "1.0.1",
-            "try-resolve": "1.0.1"
-          }
+          "dev": true
         },
         "babylon": {
           "version": "5.8.38",
@@ -7290,21 +4345,10 @@
           "dev": true
         },
         "broccoli-babel-transpiler": {
-          "version": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.2.tgz",
-          "integrity": "sha512-vFQ+aSR9J81fm3MXXQGgDxswYINHl2p5duLvRLVnpmgPDNdpdsa30gh3xnmhzR/GwWFBfUNle7aYxthlgvsN0w==",
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.4.tgz",
+          "integrity": "sha512-gI14Pqc4qbmn5RW4SuAmybLiOoYW59D+HzQyhY6WdaGMAjikKBwJN0p17phyvafQ+kvG0mUiMd83lgHLeATnEA==",
           "dev": true,
-          "requires": {
-            "babel-core": "5.8.38",
-            "broccoli-funnel": "1.2.0",
-            "broccoli-merge-trees": "1.2.4",
-            "broccoli-persistent-filter": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
-            "clone": "0.2.0",
-            "hash-for-dep": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
-            "heimdalljs-logger": "0.1.9",
-            "json-stable-stringify": "1.0.1",
-            "rsvp": "3.6.2",
-            "workerpool": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.0.tgz"
-          },
           "dependencies": {
             "clone": {
               "version": "0.2.0",
@@ -7324,33 +4368,19 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
           "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "4.0.1",
-            "minimist": "1.2.0",
-            "repeating": "1.1.3"
-          }
+          "dev": true
         },
         "ember-cli-babel": {
-          "version": "5.2.4",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz",
-          "integrity": "sha1-XOT0awjtb20h6Hhhn7aJcZ1ujhM=",
-          "dev": true,
-          "requires": {
-            "broccoli-babel-transpiler": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.2.tgz",
-            "broccoli-funnel": "1.2.0",
-            "clone": "2.1.1",
-            "ember-cli-version-checker": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-            "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz"
-          }
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.8.tgz",
+          "integrity": "sha512-Mt9OOB5RaZwjde+LYef8EgwNVCAzsYDv4ktshblaXxr4m/Xm5/7/rxEu42RNrYkoy/qWpT9uhaD+JKK4riMf+w==",
+          "dev": true
         },
         "ember-cli-version-checker": {
-          "version": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-          "integrity": "sha512-mu1Apdd19ZuDsy9WAHheFhltaJx+0ardFNM8Hb/AeRO9RokOK/bdUq/Jc1oeg0/Hl18tnxg8STG9TyJ6HgE3+g==",
-          "dev": true,
-          "requires": {
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
-          }
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
+          "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
+          "dev": true
         },
         "globals": {
           "version": "6.4.1",
@@ -7362,11 +4392,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
           "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "1.0.2",
-            "user-home": "1.1.1"
-          }
+          "dev": true
         },
         "js-tokens": {
           "version": "1.0.1",
@@ -7390,10 +4416,7 @@
           "version": "2.0.10",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
+          "dev": true
         },
         "minimist": {
           "version": "1.2.0",
@@ -7405,28 +4428,19 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
           "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
-          "dev": true,
-          "requires": {
-            "is-finite": "1.0.2"
-          }
+          "dev": true
         },
         "source-map-support": {
           "version": "0.2.10",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
           "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
           "dev": true,
-          "requires": {
-            "source-map": "0.1.32"
-          },
           "dependencies": {
             "source-map": {
               "version": "0.1.32",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
               "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
-              "dev": true,
-              "requires": {
-                "amdefine": "1.0.1"
-              }
+              "dev": true
             }
           }
         }
@@ -7437,63 +4451,12 @@
       "resolved": "https://registry.npmjs.org/ember-truth-helpers/-/ember-truth-helpers-1.3.0.tgz",
       "integrity": "sha1-btn4POmkn1K7QW1V4idCYzmmTGA=",
       "dev": true,
-      "requires": {
-        "ember-cli-babel": "5.2.4"
-      },
       "dependencies": {
         "babel-core": {
           "version": "5.8.38",
           "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
           "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
-          "dev": true,
-          "requires": {
-            "babel-plugin-constant-folding": "1.0.1",
-            "babel-plugin-dead-code-elimination": "1.0.2",
-            "babel-plugin-eval": "1.0.1",
-            "babel-plugin-inline-environment-variables": "1.0.1",
-            "babel-plugin-jscript": "1.0.4",
-            "babel-plugin-member-expression-literals": "1.0.1",
-            "babel-plugin-property-literals": "1.0.1",
-            "babel-plugin-proto-to-assign": "1.0.4",
-            "babel-plugin-react-constant-elements": "1.0.3",
-            "babel-plugin-react-display-name": "1.0.3",
-            "babel-plugin-remove-console": "1.0.1",
-            "babel-plugin-remove-debugger": "1.0.1",
-            "babel-plugin-runtime": "1.0.7",
-            "babel-plugin-undeclared-variables-check": "1.0.2",
-            "babel-plugin-undefined-to-void": "1.1.6",
-            "babylon": "5.8.38",
-            "bluebird": "2.11.0",
-            "chalk": "1.1.3",
-            "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-            "core-js": "1.2.7",
-            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "detect-indent": "3.0.1",
-            "esutils": "2.0.2",
-            "fs-readdir-recursive": "0.1.2",
-            "globals": "6.4.1",
-            "home-or-tmp": "1.0.0",
-            "is-integer": "1.0.7",
-            "js-tokens": "1.0.1",
-            "json5": "0.4.0",
-            "lodash": "3.10.1",
-            "minimatch": "2.0.10",
-            "output-file-sync": "1.1.2",
-            "path-exists": "1.0.0",
-            "path-is-absolute": "1.0.1",
-            "private": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-            "regenerator": "0.8.40",
-            "regexpu": "1.3.0",
-            "repeating": "1.1.3",
-            "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-            "shebang-regex": "1.0.0",
-            "slash": "1.0.0",
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-            "source-map-support": "0.2.10",
-            "to-fast-properties": "1.0.3",
-            "trim-right": "1.0.1",
-            "try-resolve": "1.0.1"
-          }
+          "dev": true
         },
         "babylon": {
           "version": "5.8.38",
@@ -7502,21 +4465,10 @@
           "dev": true
         },
         "broccoli-babel-transpiler": {
-          "version": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.2.tgz",
-          "integrity": "sha512-vFQ+aSR9J81fm3MXXQGgDxswYINHl2p5duLvRLVnpmgPDNdpdsa30gh3xnmhzR/GwWFBfUNle7aYxthlgvsN0w==",
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.4.tgz",
+          "integrity": "sha512-gI14Pqc4qbmn5RW4SuAmybLiOoYW59D+HzQyhY6WdaGMAjikKBwJN0p17phyvafQ+kvG0mUiMd83lgHLeATnEA==",
           "dev": true,
-          "requires": {
-            "babel-core": "5.8.38",
-            "broccoli-funnel": "1.2.0",
-            "broccoli-merge-trees": "1.2.4",
-            "broccoli-persistent-filter": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
-            "clone": "0.2.0",
-            "hash-for-dep": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
-            "heimdalljs-logger": "0.1.9",
-            "json-stable-stringify": "1.0.1",
-            "rsvp": "3.6.2",
-            "workerpool": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.0.tgz"
-          },
           "dependencies": {
             "clone": {
               "version": "0.2.0",
@@ -7536,33 +4488,19 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
           "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "4.0.1",
-            "minimist": "1.2.0",
-            "repeating": "1.1.3"
-          }
+          "dev": true
         },
         "ember-cli-babel": {
-          "version": "5.2.4",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz",
-          "integrity": "sha1-XOT0awjtb20h6Hhhn7aJcZ1ujhM=",
-          "dev": true,
-          "requires": {
-            "broccoli-babel-transpiler": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.2.tgz",
-            "broccoli-funnel": "1.2.0",
-            "clone": "2.1.1",
-            "ember-cli-version-checker": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-            "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz"
-          }
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.8.tgz",
+          "integrity": "sha512-Mt9OOB5RaZwjde+LYef8EgwNVCAzsYDv4ktshblaXxr4m/Xm5/7/rxEu42RNrYkoy/qWpT9uhaD+JKK4riMf+w==",
+          "dev": true
         },
         "ember-cli-version-checker": {
-          "version": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-          "integrity": "sha512-mu1Apdd19ZuDsy9WAHheFhltaJx+0ardFNM8Hb/AeRO9RokOK/bdUq/Jc1oeg0/Hl18tnxg8STG9TyJ6HgE3+g==",
-          "dev": true,
-          "requires": {
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
-          }
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
+          "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
+          "dev": true
         },
         "globals": {
           "version": "6.4.1",
@@ -7574,11 +4512,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
           "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "1.0.2",
-            "user-home": "1.1.1"
-          }
+          "dev": true
         },
         "js-tokens": {
           "version": "1.0.1",
@@ -7602,10 +4536,7 @@
           "version": "2.0.10",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
+          "dev": true
         },
         "minimist": {
           "version": "1.2.0",
@@ -7617,51 +4548,29 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
           "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
-          "dev": true,
-          "requires": {
-            "is-finite": "1.0.2"
-          }
+          "dev": true
         },
         "source-map-support": {
           "version": "0.2.10",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
           "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
           "dev": true,
-          "requires": {
-            "source-map": "0.1.32"
-          },
           "dependencies": {
             "source-map": {
               "version": "0.1.32",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
               "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
-              "dev": true,
-              "requires": {
-                "amdefine": "1.0.1"
-              }
+              "dev": true
             }
           }
         }
       }
     },
     "ember-try": {
-      "version": "https://registry.npmjs.org/ember-try/-/ember-try-0.2.23.tgz",
+      "version": "0.2.23",
+      "resolved": "https://registry.npmjs.org/ember-try/-/ember-try-0.2.23.tgz",
       "integrity": "sha512-kmVNsSFFafGinFhERMox3SXHoU+V1td1538SbhpslPtf7S2BZYr7JdAwOCIRoRtpcWeNdYgdQGzJZxNvUc8aLg==",
       "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "cli-table2": "0.2.0",
-        "core-object": "1.1.0",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-        "ember-try-config": "https://registry.npmjs.org/ember-try-config/-/ember-try-config-2.2.0.tgz",
-        "extend": "3.0.1",
-        "fs-extra": "0.26.7",
-        "promise-map-series": "0.2.3",
-        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-        "rsvp": "3.6.2",
-        "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
-      },
       "dependencies": {
         "core-object": {
           "version": "1.1.0",
@@ -7673,90 +4582,27 @@
           "version": "0.26.7",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
           "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.1",
-            "path-is-absolute": "1.0.1",
-            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz"
-          }
+          "dev": true
         }
       }
     },
     "ember-try-config": {
-      "version": "https://registry.npmjs.org/ember-try-config/-/ember-try-config-2.2.0.tgz",
-      "integrity": "sha512-F+BqYNKdQ06M8/HdLre5ZR68KyHFH8IXBlLQOTzGFjvUyWgikWk29ElfZj51khiWEsBNNdDrKH+DCLCESMozuQ==",
-      "dev": true,
-      "requires": {
-        "lodash": "4.17.4",
-        "node-fetch": "1.7.3",
-        "rsvp": "3.6.2",
-        "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
-      }
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ember-try-config/-/ember-try-config-2.2.0.tgz",
+      "integrity": "sha1-a+CvbHGUmBPgKseTVk/dv4M2uAc=",
+      "dev": true
     },
     "ember-uuid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ember-uuid/-/ember-uuid-1.0.0.tgz",
       "integrity": "sha1-CTLytW1kQXyriS2W48xp+JU1bfc=",
       "dev": true,
-      "requires": {
-        "ember-cli-babel": "5.2.4"
-      },
       "dependencies": {
         "babel-core": {
           "version": "5.8.38",
           "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
           "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
-          "dev": true,
-          "requires": {
-            "babel-plugin-constant-folding": "1.0.1",
-            "babel-plugin-dead-code-elimination": "1.0.2",
-            "babel-plugin-eval": "1.0.1",
-            "babel-plugin-inline-environment-variables": "1.0.1",
-            "babel-plugin-jscript": "1.0.4",
-            "babel-plugin-member-expression-literals": "1.0.1",
-            "babel-plugin-property-literals": "1.0.1",
-            "babel-plugin-proto-to-assign": "1.0.4",
-            "babel-plugin-react-constant-elements": "1.0.3",
-            "babel-plugin-react-display-name": "1.0.3",
-            "babel-plugin-remove-console": "1.0.1",
-            "babel-plugin-remove-debugger": "1.0.1",
-            "babel-plugin-runtime": "1.0.7",
-            "babel-plugin-undeclared-variables-check": "1.0.2",
-            "babel-plugin-undefined-to-void": "1.1.6",
-            "babylon": "5.8.38",
-            "bluebird": "2.11.0",
-            "chalk": "1.1.3",
-            "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-            "core-js": "1.2.7",
-            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "detect-indent": "3.0.1",
-            "esutils": "2.0.2",
-            "fs-readdir-recursive": "0.1.2",
-            "globals": "6.4.1",
-            "home-or-tmp": "1.0.0",
-            "is-integer": "1.0.7",
-            "js-tokens": "1.0.1",
-            "json5": "0.4.0",
-            "lodash": "3.10.1",
-            "minimatch": "2.0.10",
-            "output-file-sync": "1.1.2",
-            "path-exists": "1.0.0",
-            "path-is-absolute": "1.0.1",
-            "private": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-            "regenerator": "0.8.40",
-            "regexpu": "1.3.0",
-            "repeating": "1.1.3",
-            "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-            "shebang-regex": "1.0.0",
-            "slash": "1.0.0",
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-            "source-map-support": "0.2.10",
-            "to-fast-properties": "1.0.3",
-            "trim-right": "1.0.1",
-            "try-resolve": "1.0.1"
-          }
+          "dev": true
         },
         "babylon": {
           "version": "5.8.38",
@@ -7765,21 +4611,10 @@
           "dev": true
         },
         "broccoli-babel-transpiler": {
-          "version": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.2.tgz",
-          "integrity": "sha512-vFQ+aSR9J81fm3MXXQGgDxswYINHl2p5duLvRLVnpmgPDNdpdsa30gh3xnmhzR/GwWFBfUNle7aYxthlgvsN0w==",
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.4.tgz",
+          "integrity": "sha512-gI14Pqc4qbmn5RW4SuAmybLiOoYW59D+HzQyhY6WdaGMAjikKBwJN0p17phyvafQ+kvG0mUiMd83lgHLeATnEA==",
           "dev": true,
-          "requires": {
-            "babel-core": "5.8.38",
-            "broccoli-funnel": "1.2.0",
-            "broccoli-merge-trees": "1.2.4",
-            "broccoli-persistent-filter": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
-            "clone": "0.2.0",
-            "hash-for-dep": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
-            "heimdalljs-logger": "0.1.9",
-            "json-stable-stringify": "1.0.1",
-            "rsvp": "3.6.2",
-            "workerpool": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.0.tgz"
-          },
           "dependencies": {
             "clone": {
               "version": "0.2.0",
@@ -7799,33 +4634,19 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
           "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "4.0.1",
-            "minimist": "1.2.0",
-            "repeating": "1.1.3"
-          }
+          "dev": true
         },
         "ember-cli-babel": {
-          "version": "5.2.4",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz",
-          "integrity": "sha1-XOT0awjtb20h6Hhhn7aJcZ1ujhM=",
-          "dev": true,
-          "requires": {
-            "broccoli-babel-transpiler": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.2.tgz",
-            "broccoli-funnel": "1.2.0",
-            "clone": "2.1.1",
-            "ember-cli-version-checker": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-            "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz"
-          }
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.8.tgz",
+          "integrity": "sha512-Mt9OOB5RaZwjde+LYef8EgwNVCAzsYDv4ktshblaXxr4m/Xm5/7/rxEu42RNrYkoy/qWpT9uhaD+JKK4riMf+w==",
+          "dev": true
         },
         "ember-cli-version-checker": {
-          "version": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-          "integrity": "sha512-mu1Apdd19ZuDsy9WAHheFhltaJx+0ardFNM8Hb/AeRO9RokOK/bdUq/Jc1oeg0/Hl18tnxg8STG9TyJ6HgE3+g==",
-          "dev": true,
-          "requires": {
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
-          }
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
+          "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
+          "dev": true
         },
         "globals": {
           "version": "6.4.1",
@@ -7837,11 +4658,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
           "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "1.0.2",
-            "user-home": "1.1.1"
-          }
+          "dev": true
         },
         "js-tokens": {
           "version": "1.0.1",
@@ -7865,10 +4682,7 @@
           "version": "2.0.10",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
+          "dev": true
         },
         "minimist": {
           "version": "1.2.0",
@@ -7880,30 +4694,33 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
           "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
-          "dev": true,
-          "requires": {
-            "is-finite": "1.0.2"
-          }
+          "dev": true
         },
         "source-map-support": {
           "version": "0.2.10",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
           "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
           "dev": true,
-          "requires": {
-            "source-map": "0.1.32"
-          },
           "dependencies": {
             "source-map": {
               "version": "0.1.32",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
               "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
-              "dev": true,
-              "requires": {
-                "amdefine": "1.0.1"
-              }
+              "dev": true
             }
           }
+        }
+      }
+    },
+    "ember-weakmap": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/ember-weakmap/-/ember-weakmap-3.1.1.tgz",
+      "integrity": "sha512-rfW3A1m3NFsHd/NuHyBkssU0Qf0zGcJmASGfhjZc7fIQeBZvSLIFYZTej+W+YBLPtED9h/SVW63DHTRY5PUR4Q==",
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g=="
         }
       }
     },
@@ -7912,63 +4729,12 @@
       "resolved": "https://registry.npmjs.org/ember-wormhole/-/ember-wormhole-0.3.6.tgz",
       "integrity": "sha1-u+IbtUeK0lTv5P/0AZrGcQ9K2Fw=",
       "dev": true,
-      "requires": {
-        "ember-cli-babel": "5.2.4"
-      },
       "dependencies": {
         "babel-core": {
           "version": "5.8.38",
           "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
           "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
-          "dev": true,
-          "requires": {
-            "babel-plugin-constant-folding": "1.0.1",
-            "babel-plugin-dead-code-elimination": "1.0.2",
-            "babel-plugin-eval": "1.0.1",
-            "babel-plugin-inline-environment-variables": "1.0.1",
-            "babel-plugin-jscript": "1.0.4",
-            "babel-plugin-member-expression-literals": "1.0.1",
-            "babel-plugin-property-literals": "1.0.1",
-            "babel-plugin-proto-to-assign": "1.0.4",
-            "babel-plugin-react-constant-elements": "1.0.3",
-            "babel-plugin-react-display-name": "1.0.3",
-            "babel-plugin-remove-console": "1.0.1",
-            "babel-plugin-remove-debugger": "1.0.1",
-            "babel-plugin-runtime": "1.0.7",
-            "babel-plugin-undeclared-variables-check": "1.0.2",
-            "babel-plugin-undefined-to-void": "1.1.6",
-            "babylon": "5.8.38",
-            "bluebird": "2.11.0",
-            "chalk": "1.1.3",
-            "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-            "core-js": "1.2.7",
-            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "detect-indent": "3.0.1",
-            "esutils": "2.0.2",
-            "fs-readdir-recursive": "0.1.2",
-            "globals": "6.4.1",
-            "home-or-tmp": "1.0.0",
-            "is-integer": "1.0.7",
-            "js-tokens": "1.0.1",
-            "json5": "0.4.0",
-            "lodash": "3.10.1",
-            "minimatch": "2.0.10",
-            "output-file-sync": "1.1.2",
-            "path-exists": "1.0.0",
-            "path-is-absolute": "1.0.1",
-            "private": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-            "regenerator": "0.8.40",
-            "regexpu": "1.3.0",
-            "repeating": "1.1.3",
-            "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-            "shebang-regex": "1.0.0",
-            "slash": "1.0.0",
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-            "source-map-support": "0.2.10",
-            "to-fast-properties": "1.0.3",
-            "trim-right": "1.0.1",
-            "try-resolve": "1.0.1"
-          }
+          "dev": true
         },
         "babylon": {
           "version": "5.8.38",
@@ -7977,21 +4743,10 @@
           "dev": true
         },
         "broccoli-babel-transpiler": {
-          "version": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.2.tgz",
-          "integrity": "sha512-vFQ+aSR9J81fm3MXXQGgDxswYINHl2p5duLvRLVnpmgPDNdpdsa30gh3xnmhzR/GwWFBfUNle7aYxthlgvsN0w==",
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.4.tgz",
+          "integrity": "sha512-gI14Pqc4qbmn5RW4SuAmybLiOoYW59D+HzQyhY6WdaGMAjikKBwJN0p17phyvafQ+kvG0mUiMd83lgHLeATnEA==",
           "dev": true,
-          "requires": {
-            "babel-core": "5.8.38",
-            "broccoli-funnel": "1.2.0",
-            "broccoli-merge-trees": "1.2.4",
-            "broccoli-persistent-filter": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
-            "clone": "0.2.0",
-            "hash-for-dep": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
-            "heimdalljs-logger": "0.1.9",
-            "json-stable-stringify": "1.0.1",
-            "rsvp": "3.6.2",
-            "workerpool": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.0.tgz"
-          },
           "dependencies": {
             "clone": {
               "version": "0.2.0",
@@ -8011,33 +4766,19 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
           "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "4.0.1",
-            "minimist": "1.2.0",
-            "repeating": "1.1.3"
-          }
+          "dev": true
         },
         "ember-cli-babel": {
-          "version": "5.2.4",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz",
-          "integrity": "sha1-XOT0awjtb20h6Hhhn7aJcZ1ujhM=",
-          "dev": true,
-          "requires": {
-            "broccoli-babel-transpiler": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.2.tgz",
-            "broccoli-funnel": "1.2.0",
-            "clone": "2.1.1",
-            "ember-cli-version-checker": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-            "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz"
-          }
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.8.tgz",
+          "integrity": "sha512-Mt9OOB5RaZwjde+LYef8EgwNVCAzsYDv4ktshblaXxr4m/Xm5/7/rxEu42RNrYkoy/qWpT9uhaD+JKK4riMf+w==",
+          "dev": true
         },
         "ember-cli-version-checker": {
-          "version": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-          "integrity": "sha512-mu1Apdd19ZuDsy9WAHheFhltaJx+0ardFNM8Hb/AeRO9RokOK/bdUq/Jc1oeg0/Hl18tnxg8STG9TyJ6HgE3+g==",
-          "dev": true,
-          "requires": {
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
-          }
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
+          "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
+          "dev": true
         },
         "globals": {
           "version": "6.4.1",
@@ -8049,11 +4790,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
           "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "1.0.2",
-            "user-home": "1.1.1"
-          }
+          "dev": true
         },
         "js-tokens": {
           "version": "1.0.1",
@@ -8077,10 +4814,7 @@
           "version": "2.0.10",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
+          "dev": true
         },
         "minimist": {
           "version": "1.2.0",
@@ -8092,79 +4826,53 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
           "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
-          "dev": true,
-          "requires": {
-            "is-finite": "1.0.2"
-          }
+          "dev": true
         },
         "source-map-support": {
           "version": "0.2.10",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
           "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
           "dev": true,
-          "requires": {
-            "source-map": "0.1.32"
-          },
           "dependencies": {
             "source-map": {
               "version": "0.1.32",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
               "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
-              "dev": true,
-              "requires": {
-                "amdefine": "1.0.1"
-              }
+              "dev": true
             }
           }
         }
       }
     },
     "encodeurl": {
-      "version": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
     },
     "encoding": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "dev": true,
-      "requires": {
-        "iconv-lite": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
-      }
+      "dev": true
     },
     "engine.io": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.0.tgz",
       "integrity": "sha1-PutfJky3XbvsG6rqJtYfWk6s4qo=",
       "dev": true,
-      "requires": {
-        "accepts": "1.3.3",
-        "base64id": "0.1.0",
-        "cookie": "0.3.1",
-        "debug": "2.3.3",
-        "engine.io-parser": "1.3.1",
-        "ws": "1.1.1"
-      },
       "dependencies": {
         "accepts": {
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
           "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
-          "dev": true,
-          "requires": {
-            "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-            "negotiator": "0.6.1"
-          }
+          "dev": true
         },
         "debug": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.2"
-          }
+          "dev": true
         },
         "ms": {
           "version": "0.7.2",
@@ -8179,35 +4887,12 @@
       "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.0.tgz",
       "integrity": "sha1-e3MOQSdBQIdZbZvjyI0rxf22z1w=",
       "dev": true,
-      "requires": {
-        "component-emitter": "1.2.1",
-        "component-inherit": "0.0.3",
-        "debug": "2.3.3",
-        "engine.io-parser": "1.3.1",
-        "has-cors": "1.1.0",
-        "indexof": "0.0.1",
-        "parsejson": "0.0.3",
-        "parseqs": "0.0.5",
-        "parseuri": "0.0.5",
-        "ws": "1.1.1",
-        "xmlhttprequest-ssl": "1.5.3",
-        "yeast": "0.1.2"
-      },
       "dependencies": {
-        "component-emitter": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-          "dev": true
-        },
         "debug": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.2"
-          }
+          "dev": true
         },
         "ms": {
           "version": "0.7.2",
@@ -8222,23 +4907,12 @@
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.1.tgz",
       "integrity": "sha1-lVTxrjMQfW+9FwylRm0vgz9qB88=",
       "dev": true,
-      "requires": {
-        "after": "0.8.1",
-        "arraybuffer.slice": "0.0.6",
-        "base64-arraybuffer": "0.1.5",
-        "blob": "0.0.4",
-        "has-binary": "0.1.6",
-        "wtf-8": "1.0.0"
-      },
       "dependencies": {
         "has-binary": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
           "integrity": "sha1-JTJvOc+k9hath4eJTjryz7x7bhA=",
-          "dev": true,
-          "requires": {
-            "isarray": "0.0.1"
-          }
+          "dev": true
         },
         "isarray": {
           "version": "0.0.1",
@@ -8263,19 +4937,12 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/error/-/error-7.0.2.tgz",
       "integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
-      "dev": true,
-      "requires": {
-        "string-template": "0.2.1",
-        "xtend": "4.0.1"
-      }
+      "dev": true
     },
     "error-ex": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-      "requires": {
-        "is-arrayish": "0.2.1"
-      }
+      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw="
     },
     "es6-promise": {
       "version": "1.0.0",
@@ -8294,24 +4961,145 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
+    "eslint": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+      "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+          "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+          "dev": true
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true
+        },
+        "external-editor": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
+          "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+          "dev": true
+        },
+        "globals": {
+          "version": "11.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.4.0.tgz",
+          "integrity": "sha512-Dyzmifil8n/TmSqYDEXbm+C8yitzJQqQIlJQLNRMwa+BOUJpRC19pyVeN12JAjt61xonvXjtff+hJruTRXn5HA==",
+          "dev": true
+        },
+        "inquirer": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+          "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "mute-stream": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+          "dev": true
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "dev": true
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "dev": true
+        },
+        "tmp": {
+          "version": "0.0.33",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+          "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+          "dev": true
+        }
+      }
+    },
     "eslint-plugin-ember-suave": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-ember-suave/-/eslint-plugin-ember-suave-1.0.0.tgz",
       "integrity": "sha1-6n0jKhJlYtzYse46onAKw7Ym5RQ=",
-      "dev": true,
-      "requires": {
-        "requireindex": "1.1.0"
-      }
+      "dev": true
     },
     "eslint-scope": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
       "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
-      "dev": true,
-      "requires": {
-        "esrecurse": "4.2.0",
-        "estraverse": "4.2.0"
-      }
+      "dev": true
+    },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
+    },
+    "espree": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+      "dev": true
     },
     "esprima-fb": {
       "version": "15001.1001.0-dev-harmony-fb",
@@ -8322,20 +5110,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
       "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
-      "dev": true,
-      "requires": {
-        "estraverse": "4.2.0"
-      }
+      "dev": true
     },
     "esrecurse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
-      "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
-      "dev": true,
-      "requires": {
-        "estraverse": "4.2.0",
-        "object-assign": "4.1.1"
-      }
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true
     },
     "estraverse": {
       "version": "4.2.0",
@@ -8367,49 +5148,28 @@
       "dev": true
     },
     "exec-file-sync": {
-      "version": "https://registry.npmjs.org/exec-file-sync/-/exec-file-sync-2.0.2.tgz",
-      "integrity": "sha512-81pg504WxoHz0AjNL7/X7skM4oGybpRlaHIyMtrOAhYfXS8jNPEM/dcrwezN5GqFblkYjrUBItbGUb/MUR1UfQ==",
-      "dev": true,
-      "requires": {
-        "is-obj": "1.0.1",
-        "object-assign": "4.1.1",
-        "spawn-sync": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz"
-      }
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/exec-file-sync/-/exec-file-sync-2.0.2.tgz",
+      "integrity": "sha1-WNRB20bkDebR8w3lvgInhb2J4yg=",
+      "dev": true
     },
     "exec-sh": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
       "integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
-      "dev": true,
-      "requires": {
-        "merge": "1.2.0"
-      }
+      "dev": true
     },
     "execa": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
       "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
       "dev": true,
-      "requires": {
-        "cross-spawn": "5.1.0",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
-      },
       "dependencies": {
         "cross-spawn": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "4.1.1",
-            "shebang-command": "1.2.0",
-            "which": "https://registry.npmjs.org/which/-/which-1.3.0.tgz"
-          }
+          "dev": true
         }
       }
     },
@@ -8431,74 +5191,34 @@
       "dev": true
     },
     "exit-hook": {
-      "version": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-      "integrity": "sha512-MsG3prOVw1WtLXAZbM3KiYtooKR1LvxHh3VHsVtIy0uiUu8usxgB/94DP2HxtD/661lLdB6yzQ09lGJSQr6nkg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
       "dev": true
     },
     "expand-brackets": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-      "dev": true,
-      "requires": {
-        "is-posix-bracket": "0.1.1"
-      }
+      "dev": true
     },
     "expand-range": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "dev": true,
-      "requires": {
-        "fill-range": "2.2.3"
-      }
+      "dev": true
     },
     "expand-tilde": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
       "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
-      "dev": true,
-      "requires": {
-        "os-homedir": "1.0.2"
-      }
+      "dev": true
     },
     "express": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
-      "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
+      "version": "4.16.3",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
+      "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
       "dev": true,
-      "requires": {
-        "accepts": "1.3.4",
-        "array-flatten": "1.1.1",
-        "body-parser": "1.18.2",
-        "content-disposition": "0.5.2",
-        "content-type": "1.0.4",
-        "cookie": "0.3.1",
-        "cookie-signature": "1.0.6",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-        "depd": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-        "encodeurl": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
-        "finalhandler": "1.1.0",
-        "fresh": "0.5.2",
-        "merge-descriptors": "1.0.1",
-        "methods": "1.1.2",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
-        "path-to-regexp": "0.1.7",
-        "proxy-addr": "2.0.2",
-        "qs": "6.5.1",
-        "range-parser": "1.2.0",
-        "safe-buffer": "5.1.1",
-        "send": "0.16.1",
-        "serve-static": "1.13.1",
-        "setprototypeof": "1.1.0",
-        "statuses": "1.3.1",
-        "type-is": "1.6.15",
-        "utils-merge": "1.0.1",
-        "vary": "1.1.2"
-      },
       "dependencies": {
         "qs": {
           "version": "6.5.1",
@@ -8518,40 +5238,26 @@
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
-      "requires": {
-        "assign-symbols": "1.0.0",
-        "is-extendable": "1.0.1"
-      },
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-          "dev": true,
-          "requires": {
-            "is-plain-object": "2.0.4"
-          }
+          "dev": true
         }
       }
     },
     "external-editor": {
-      "version": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
-      "integrity": "sha512-0XYlP43jzxMgJjugDJ85Z0UDPnowkUbfFztNvsSGC9sJVIk97MZbGEb9WAhIVH0UgNxoLj/9ZQgB4CHJyz2GGQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
+      "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
       "dev": true,
-      "requires": {
-        "extend": "3.0.1",
-        "spawn-sync": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
-        "tmp": "0.0.29"
-      },
       "dependencies": {
         "tmp": {
           "version": "0.0.29",
           "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
           "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "1.0.2"
-          }
+          "dev": true
         }
       }
     },
@@ -8559,19 +5265,23 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-      "dev": true,
-      "requires": {
-        "is-extglob": "1.0.0"
-      }
+      "dev": true
     },
     "extsprintf": {
-      "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
     },
     "fast-levenshtein": {
@@ -8583,26 +5293,13 @@
     "fast-ordered-set": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/fast-ordered-set/-/fast-ordered-set-1.0.3.tgz",
-      "integrity": "sha1-P7s2Y097555PftvbSjV97iXRhOs=",
-      "requires": {
-        "blank-object": "1.0.2"
-      }
+      "integrity": "sha1-P7s2Y097555PftvbSjV97iXRhOs="
     },
     "fast-sourcemap-concat": {
-      "version": "https://registry.npmjs.org/fast-sourcemap-concat/-/fast-sourcemap-concat-1.2.3.tgz",
-      "integrity": "sha512-7NuEqPACNYdK5BvUXdCsUQZkAmJQEtHC4A9WwqoBttHT477pxRr7IkksMyqBv7C0VslnXIHc+e4ZSFRaDR/Bdw==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/fast-sourcemap-concat/-/fast-sourcemap-concat-1.2.5.tgz",
+      "integrity": "sha512-/PXSbt881cDvqNpO9z2F/jxRQpLO7Ihqhw98/DHTvmsHfsUsNR+HsP8g1HyTA8uDyPkAXLp9kRPXqq+lLY/wyw==",
       "dev": true,
-      "requires": {
-        "chalk": "0.5.1",
-        "fs-extra": "0.30.0",
-        "heimdalljs-logger": "0.1.9",
-        "memory-streams": "0.1.2",
-        "mkdirp": "0.5.1",
-        "rsvp": "3.6.2",
-        "source-map": "0.4.4",
-        "source-map-url": "0.3.0",
-        "sourcemap-validator": "https://registry.npmjs.org/sourcemap-validator/-/sourcemap-validator-1.0.6.tgz"
-      },
       "dependencies": {
         "ansi-regex": {
           "version": "0.2.1",
@@ -8620,54 +5317,31 @@
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "1.1.0",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "0.1.0",
-            "strip-ansi": "0.3.0",
-            "supports-color": "0.2.0"
-          }
+          "dev": true
         },
         "fs-extra": {
           "version": "0.30.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
           "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.1",
-            "path-is-absolute": "1.0.1",
-            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz"
-          }
+          "dev": true
         },
         "has-ansi": {
           "version": "0.1.0",
           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
           "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "0.2.1"
-          }
+          "dev": true
         },
         "source-map": {
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
+          "dev": true
         },
         "strip-ansi": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
           "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "0.2.1"
-          }
+          "dev": true
         },
         "supports-color": {
           "version": "0.2.0",
@@ -8681,37 +5355,25 @@
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
       "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
-      "dev": true,
-      "requires": {
-        "websocket-driver": "0.7.0"
-      }
+      "dev": true
     },
     "fb-watchman": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
       "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
-      "dev": true,
-      "requires": {
-        "bser": "2.0.0"
-      }
+      "dev": true
     },
     "figures": {
-      "version": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-      "integrity": "sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==",
-      "dev": true,
-      "requires": {
-        "escape-string-regexp": "1.0.5"
-      }
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true
     },
     "file-entry-cache": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-      "dev": true,
-      "requires": {
-        "flat-cache": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
-        "object-assign": "4.1.1"
-      }
+      "dev": true
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -8720,37 +5382,22 @@
       "dev": true
     },
     "filesize": {
-      "version": "https://registry.npmjs.org/filesize/-/filesize-3.5.11.tgz",
-      "integrity": "sha512-ZH7loueKBoDb7yG9esn1U+fgq7BzlzW6NRi5/rMdxIZ05dj7GFD/Xc5rq2CDt5Yq86CyfSYVyx4242QQNZbx1g==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
+      "integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==",
       "dev": true
     },
     "fill-range": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-      "dev": true,
-      "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "1.1.7",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
-      }
+      "dev": true
     },
     "finalhandler": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
-      "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
-      "dev": true,
-      "requires": {
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-        "encodeurl": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
-        "statuses": "1.3.1",
-        "unpipe": "1.0.0"
-      }
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+      "dev": true
     },
     "find-index": {
       "version": "1.1.0",
@@ -8762,18 +5409,11 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-      "requires": {
-        "path-exists": "2.1.0",
-        "pinkie-promise": "2.0.1"
-      },
       "dependencies": {
         "path-exists": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s="
         }
       }
     },
@@ -8781,26 +5421,13 @@
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",
       "integrity": "sha1-QAQ5Kee8YK3wt/SCfExudaDeyhI=",
-      "dev": true,
-      "requires": {
-        "detect-file": "0.1.0",
-        "is-glob": "2.0.1",
-        "micromatch": "2.3.11",
-        "resolve-dir": "0.1.1"
-      }
+      "dev": true
     },
     "fireworm": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/fireworm/-/fireworm-0.7.1.tgz",
       "integrity": "sha1-zPIPeUHxCIg/zduZOD2+bhhhx1g=",
       "dev": true,
-      "requires": {
-        "async": "0.2.10",
-        "is-type": "0.0.1",
-        "lodash.debounce": "3.1.1",
-        "lodash.flatten": "3.0.2",
-        "minimatch": "3.0.4"
-      },
       "dependencies": {
         "async": {
           "version": "0.2.10",
@@ -8811,15 +5438,10 @@
       }
     },
     "flat-cache": {
-      "version": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
-      "integrity": "sha512-L6SguNWSBopIZQTesdJANjwIFboIsDlKeh7PUPOa7mvXOJfYU767vCnft5Fk9stm/U0rcCrA6uY2MovQgrAcgg==",
-      "dev": true,
-      "requires": {
-        "circular-json": "0.3.3",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
-      }
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "dev": true
     },
     "for-in": {
       "version": "1.0.2",
@@ -8831,10 +5453,7 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "dev": true,
-      "requires": {
-        "for-in": "1.0.2"
-      }
+      "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -8844,12 +5463,7 @@
     "form-data": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-      "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz"
-      }
+      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE="
     },
     "forwarded": {
       "version": "0.1.2",
@@ -8861,10 +5475,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
-      "dev": true,
-      "requires": {
-        "map-cache": "0.2.2"
-      }
+      "dev": true
     },
     "fresh": {
       "version": "0.5.2",
@@ -8879,25 +5490,9 @@
       "dev": true
     },
     "fs-extra": {
-      "version": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
-      "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "4.0.0",
-        "universalify": "0.1.1"
-      },
-      "dependencies": {
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11"
-          }
-        }
-      }
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
+      "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU="
     },
     "fs-readdir-recursive": {
       "version": "0.1.2",
@@ -8905,14 +5500,9 @@
       "integrity": "sha1-MVtPuMHKW4xH3v7zGdBz2tNWgFk="
     },
     "fs-tree-diff": {
-      "version": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.7.tgz",
-      "integrity": "sha512-dJwDX6NBH7IfdfFjZAdHCZ6fIKc8LwR7kzqUhYRFJuX4g9ctG/7cuqJuwegGQsyLEykp6Z4krq+yIFMQlt7d9Q==",
-      "requires": {
-        "heimdalljs-logger": "0.1.9",
-        "object-assign": "4.1.1",
-        "path-posix": "1.0.0",
-        "symlink-or-copy": "1.1.8"
-      }
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.7.tgz",
+      "integrity": "sha512-dJwDX6NBH7IfdfFjZAdHCZ6fIKc8LwR7kzqUhYRFJuX4g9ctG/7cuqJuwegGQsyLEykp6Z4krq+yIFMQlt7d9Q=="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -8925,10 +5515,6 @@
       "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
       "dev": true,
       "optional": true,
-      "requires": {
-        "nan": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-        "node-pre-gyp": "0.6.39"
-      },
       "dependencies": {
         "abbrev": {
           "version": "1.1.0",
@@ -8942,11 +5528,7 @@
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
           "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
+          "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
@@ -8966,11 +5548,7 @@
           "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
           "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.2.9"
-          }
+          "optional": true
         },
         "asn1": {
           "version": "0.2.3",
@@ -9018,38 +5596,25 @@
           "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
           "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
+          "optional": true
         },
         "block-stream": {
           "version": "0.0.9",
           "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
           "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3"
-          }
+          "dev": true
         },
         "boom": {
           "version": "2.10.1",
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.7",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
           "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
-          "dev": true,
-          "requires": {
-            "balanced-match": "0.4.2",
-            "concat-map": "0.0.1"
-          }
+          "dev": true
         },
         "buffer-shims": {
           "version": "1.0.0",
@@ -9081,10 +5646,7 @@
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
           "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-          "dev": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
@@ -9108,10 +5670,7 @@
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
           "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1"
-          }
+          "dev": true
         },
         "dashdash": {
           "version": "1.14.1",
@@ -9119,9 +5678,6 @@
           "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "dev": true,
           "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -9137,10 +5693,7 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
           "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
+          "optional": true
         },
         "deep-extend": {
           "version": "0.4.2",
@@ -9174,10 +5727,7 @@
           "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
           "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
+          "optional": true
         },
         "extend": {
           "version": "3.0.1",
@@ -9204,12 +5754,7 @@
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
-          }
+          "optional": true
         },
         "fs.realpath": {
           "version": "1.0.0",
@@ -9221,42 +5766,21 @@
           "version": "1.0.11",
           "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
           "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
-          }
+          "dev": true
         },
         "fstream-ignore": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
           "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
-          }
+          "optional": true
         },
         "gauge": {
           "version": "2.7.4",
           "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "aproba": "1.1.1",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
-          }
+          "optional": true
         },
         "getpass": {
           "version": "0.1.7",
@@ -9264,9 +5788,6 @@
           "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
           "dev": true,
           "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -9281,15 +5802,7 @@
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+          "dev": true
         },
         "graceful-fs": {
           "version": "4.1.11",
@@ -9309,11 +5822,7 @@
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
           "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
-          }
+          "optional": true
         },
         "has-unicode": {
           "version": "2.0.1",
@@ -9326,13 +5835,7 @@
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
           "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
+          "dev": true
         },
         "hoek": {
           "version": "2.16.3",
@@ -9345,22 +5848,13 @@
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.0",
-            "sshpk": "1.13.0"
-          }
+          "optional": true
         },
         "inflight": {
           "version": "1.0.6",
           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-          "dev": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
+          "dev": true
         },
         "inherits": {
           "version": "2.0.3",
@@ -9379,10 +5873,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
+          "dev": true
         },
         "is-typedarray": {
           "version": "1.0.0",
@@ -9409,10 +5900,7 @@
           "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
           "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
+          "optional": true
         },
         "jsbn": {
           "version": "0.1.1",
@@ -9433,10 +5921,7 @@
           "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
           "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "jsonify": "0.0.0"
-          }
+          "optional": true
         },
         "json-stringify-safe": {
           "version": "5.0.1",
@@ -9458,12 +5943,6 @@
           "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
           "dev": true,
           "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.0.2",
-            "json-schema": "0.2.3",
-            "verror": "1.3.6"
-          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -9484,19 +5963,13 @@
           "version": "2.1.15",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
           "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-          "dev": true,
-          "requires": {
-            "mime-db": "1.27.0"
-          }
+          "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.7"
-          }
+          "dev": true
         },
         "minimist": {
           "version": "0.0.8",
@@ -9508,10 +5981,7 @@
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
+          "dev": true
         },
         "ms": {
           "version": "2.0.0",
@@ -9525,44 +5995,21 @@
           "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz",
           "integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "detect-libc": "1.0.2",
-            "hawk": "3.1.3",
-            "mkdirp": "0.5.1",
-            "nopt": "4.0.1",
-            "npmlog": "4.1.0",
-            "rc": "1.2.1",
-            "request": "2.81.0",
-            "rimraf": "2.6.1",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.0"
-          }
+          "optional": true
         },
         "nopt": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
-          }
+          "optional": true
         },
         "npmlog": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
           "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
-          }
+          "optional": true
         },
         "number-is-nan": {
           "version": "1.0.1",
@@ -9588,10 +6035,7 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "dev": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
+          "dev": true
         },
         "os-homedir": {
           "version": "1.0.2",
@@ -9612,11 +6056,7 @@
           "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
           "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
-          }
+          "optional": true
         },
         "path-is-absolute": {
           "version": "1.0.1",
@@ -9657,12 +6097,6 @@
           "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
           "dev": true,
           "optional": true,
-          "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
-          },
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
@@ -9677,56 +6111,20 @@
           "version": "2.2.9",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
           "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
-          "dev": true,
-          "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.1",
-            "util-deprecate": "1.0.2"
-          }
+          "dev": true
         },
         "request": {
           "version": "2.81.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
           "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.0.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.0.1"
-          }
+          "optional": true
         },
         "rimraf": {
           "version": "2.6.1",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
           "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-          "dev": true,
-          "requires": {
-            "glob": "7.1.2"
-          }
+          "dev": true
         },
         "safe-buffer": {
           "version": "5.0.1",
@@ -9759,10 +6157,7 @@
           "version": "1.0.9",
           "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
           "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
+          "dev": true
         },
         "sshpk": {
           "version": "1.13.0",
@@ -9770,17 +6165,6 @@
           "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
           "dev": true,
           "optional": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jodid25519": "1.0.2",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -9791,25 +6175,17 @@
             }
           }
         },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
         "string_decoder": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
           "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
+          "dev": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true
         },
         "stringstream": {
           "version": "0.0.5",
@@ -9822,10 +6198,7 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
+          "dev": true
         },
         "strip-json-comments": {
           "version": "2.0.1",
@@ -9838,49 +6211,28 @@
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
           "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-          "dev": true,
-          "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
-          }
+          "dev": true
         },
         "tar-pack": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
           "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "debug": "2.6.8",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.2.9",
-            "rimraf": "2.6.1",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
-          }
+          "optional": true
         },
         "tough-cookie": {
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
           "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
+          "optional": true
         },
         "tunnel-agent": {
           "version": "0.6.0",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
+          "optional": true
         },
         "tweetnacl": {
           "version": "0.14.5",
@@ -9914,20 +6266,14 @@
           "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
           "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "extsprintf": "1.0.2"
-          }
+          "optional": true
         },
         "wide-align": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
           "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "string-width": "1.0.2"
-          }
+          "optional": true
         },
         "wrappy": {
           "version": "1.0.2",
@@ -9940,13 +6286,7 @@
     "fstream": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "inherits": "2.0.3",
-        "mkdirp": "0.5.1",
-        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz"
-      }
+      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -9957,36 +6297,22 @@
     "gauge": {
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-      "requires": {
-        "aproba": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.2"
-      }
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c="
     },
     "gaze": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
-      "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
-      "requires": {
-        "globule": "1.2.0"
-      }
+      "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU="
     },
     "generate-function": {
-      "version": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-      "integrity": "sha512-X46lB9wLCsgkyagCmX2Dev5od5j6niCr3UeMbXVDBVO4tlpXp3o4OFh+0gPTlkD3ZMixU8PCKxf0IMGQvPo8HQ=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
     },
     "generate-object-property": {
-      "version": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha512-TuOwZWgJ2VAMEGJvAyPWvpqxSANF0LDpmyHauMjFYzaACvn+QTT/AZomvPCzVBV7yDN3OmwHQ5OvHaeLKre3JQ==",
-      "requires": {
-        "is-property": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
-      }
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA="
     },
     "get-caller-file": {
       "version": "1.0.2",
@@ -10014,9 +6340,6 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "requires": {
-        "assert-plus": "1.0.0"
-      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -10036,9 +6359,6 @@
       "resolved": "https://registry.npmjs.org/git-repo-version/-/git-repo-version-0.4.1.tgz",
       "integrity": "sha1-dfq5oKTshHB1Ww7qf9qm+dQUU78=",
       "dev": true,
-      "requires": {
-        "git-repo-info": "1.2.0"
-      },
       "dependencies": {
         "git-repo-info": {
           "version": "1.2.0",
@@ -10051,56 +6371,31 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
-      }
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ=="
     },
     "glob-base": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "dev": true,
-      "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
-      }
+      "dev": true
     },
     "glob-parent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "dev": true,
-      "requires": {
-        "is-glob": "2.0.1"
-      }
+      "dev": true
     },
     "global-modules": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
       "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
-      "dev": true,
-      "requires": {
-        "global-prefix": "0.1.5",
-        "is-windows": "0.2.0"
-      }
+      "dev": true
     },
     "global-prefix": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
       "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
-      "dev": true,
-      "requires": {
-        "homedir-polyfill": "1.0.1",
-        "ini": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-        "is-windows": "0.2.0",
-        "which": "https://registry.npmjs.org/which/-/which-1.3.0.tgz"
-      }
+      "dev": true
     },
     "globals": {
       "version": "9.18.0",
@@ -10111,25 +6406,12 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-      "dev": true,
-      "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
-      }
+      "dev": true
     },
     "globule": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.0.tgz",
-      "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
-      "requires": {
-        "glob": "7.1.2",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4"
-      }
+      "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk="
     },
     "graceful-fs": {
       "version": "4.1.11",
@@ -10153,12 +6435,6 @@
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
-      "requires": {
-        "async": "1.5.2",
-        "optimist": "0.6.1",
-        "source-map": "0.4.4",
-        "uglify-js": "2.8.29"
-      },
       "dependencies": {
         "async": {
           "version": "1.5.2",
@@ -10170,39 +6446,25 @@
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
+          "dev": true
         }
       }
     },
     "har-validator": {
-      "version": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-      "integrity": "sha512-P6tFV+wCcUL3nbyTDAvveDySfbhy0XkDtAIfZP6HITjM2WUsiPna/Eg1Yy93SFXvahqoX+kt0n+6xlXKDXYowA==",
-      "requires": {
-        "chalk": "1.1.3",
-        "commander": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-        "is-my-json-valid": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz",
-        "pinkie-promise": "2.0.1"
-      }
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+      "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0="
     },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "requires": {
-        "ansi-regex": "2.1.1"
-      }
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE="
     },
     "has-binary": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
       "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow=",
       "dev": true,
-      "requires": {
-        "isarray": "0.0.1"
-      },
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
@@ -10219,9 +6481,9 @@
       "dev": true
     },
     "has-flag": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
     "has-unicode": {
@@ -10234,11 +6496,6 @@
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
-      "requires": {
-        "get-value": "2.0.6",
-        "has-values": "1.0.0",
-        "isobject": "3.0.1"
-      },
       "dependencies": {
         "isobject": {
           "version": "3.0.1",
@@ -10253,28 +6510,18 @@
       "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
-      "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
-      },
       "dependencies": {
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz"
-              }
+              "dev": true
             }
           }
         },
@@ -10282,41 +6529,24 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz"
-          }
+          "dev": true
         }
       }
     },
     "hash-for-dep": {
-      "version": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
-      "integrity": "sha512-NE//rDaCFpWHViw30YM78OAGBShU+g4dnUGY3UWGyEzPOGYg/ptOjk32nEc+bC1xz+RfK5UIs6lOL6eQdrV4Ow==",
-      "requires": {
-        "broccoli-kitchen-sink-helpers": "0.3.1",
-        "heimdalljs": "0.2.5",
-        "heimdalljs-logger": "0.1.9",
-        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz"
-      }
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
+      "integrity": "sha512-NE//rDaCFpWHViw30YM78OAGBShU+g4dnUGY3UWGyEzPOGYg/ptOjk32nEc+bC1xz+RfK5UIs6lOL6eQdrV4Ow=="
     },
     "hawk": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "requires": {
-        "boom": "2.10.1",
-        "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
-        "sntp": "1.0.9"
-      }
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ="
     },
     "heimdalljs": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.2.5.tgz",
       "integrity": "sha1-aqVDCO7nk7ZCz/nPlHgURfN3MKw=",
-      "requires": {
-        "rsvp": "3.2.1"
-      },
       "dependencies": {
         "rsvp": {
           "version": "3.2.1",
@@ -10329,25 +6559,18 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/heimdalljs-fs-monitor/-/heimdalljs-fs-monitor-0.1.0.tgz",
       "integrity": "sha1-1ASmVojGcUxIVGntNJXaSFNEAnI=",
-      "dev": true,
-      "requires": {
-        "heimdalljs": "0.2.5",
-        "heimdalljs-logger": "0.1.9"
-      }
+      "dev": true
     },
     "heimdalljs-graph": {
-      "version": "https://registry.npmjs.org/heimdalljs-graph/-/heimdalljs-graph-0.3.4.tgz",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/heimdalljs-graph/-/heimdalljs-graph-0.3.4.tgz",
       "integrity": "sha512-2DXgPIxdatgtBOjlh5qeVeHIGMTC2V9ujEvUhVJBVOVwqnU41g1OuGaRugLi6rvk0E+u1koYkfPeptybV8ZJ4g==",
       "dev": true
     },
     "heimdalljs-logger": {
       "version": "0.1.9",
       "resolved": "https://registry.npmjs.org/heimdalljs-logger/-/heimdalljs-logger-0.1.9.tgz",
-      "integrity": "sha1-12raTkW3u294b8nAEKaOsuL68XY=",
-      "requires": {
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-        "heimdalljs": "0.2.5"
-      }
+      "integrity": "sha1-12raTkW3u294b8nAEKaOsuL68XY="
     },
     "hoek": {
       "version": "2.16.3",
@@ -10357,80 +6580,52 @@
     "home-or-tmp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-      "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
-      }
+      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg="
     },
     "homedir-polyfill": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
-      "dev": true,
-      "requires": {
-        "parse-passwd": "1.0.0"
-      }
+      "dev": true
     },
     "hosted-git-info": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
+      "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
     },
     "http-errors": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
-      "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
-      "dev": true,
-      "requires": {
-        "depd": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-        "inherits": "2.0.3",
-        "setprototypeof": "1.0.3",
-        "statuses": "1.3.1"
-      },
-      "dependencies": {
-        "depd": {
-          "version": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-          "integrity": "sha512-Jlk9xvkTDGXwZiIDyoM7+3AsuvJVoyOpRupvEVy9nX3YO3/ieZxhlgh8GpLNZ8AY7HjO6y2YwpMSh1ejhu3uIw==",
-          "dev": true
-        },
-        "setprototypeof": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-          "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
-          "dev": true
-        }
-      }
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+      "dev": true
     },
     "http-parser-js": {
-      "version": "0.4.9",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.9.tgz",
-      "integrity": "sha1-6hoE+2St/wJC6ZdPKX3Uw8rSceE=",
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.11.tgz",
+      "integrity": "sha512-QCR5O2AjjMW8Mo4HyI1ctFcv+O99j/0g367V3YoVnrNw5hkDvAWZD0lWGcc+F4yN3V55USPCVix4efb75HxFfA==",
       "dev": true
     },
     "http-proxy": {
       "version": "1.16.2",
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
       "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
-      "dev": true,
-      "requires": {
-        "eventemitter3": "1.2.0",
-        "requires-port": "1.0.0"
-      }
+      "dev": true
     },
     "http-signature": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-      "requires": {
-        "assert-plus": "0.2.0",
-        "jsprim": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-        "sshpk": "1.13.1"
-      }
+      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8="
     },
     "iconv-lite": {
-      "version": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
       "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+    },
+    "ignore": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
+      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
+      "dev": true
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -10451,10 +6646,7 @@
     "indent-string": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-      "requires": {
-        "repeating": "2.0.1"
-      }
+      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA="
     },
     "indexof": {
       "version": "0.0.1",
@@ -10471,11 +6663,7 @@
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
-      }
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
     },
     "inherits": {
       "version": "2.0.3",
@@ -10483,7 +6671,8 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
-      "version": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
@@ -10492,13 +6681,6 @@
       "resolved": "https://registry.npmjs.org/inline-source-map-comment/-/inline-source-map-comment-1.0.5.tgz",
       "integrity": "sha1-UKikTCp5DfrEQbXJTszVRiY1+vY=",
       "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "get-stdin": "4.0.1",
-        "minimist": "1.2.0",
-        "sum-up": "1.0.3",
-        "xtend": "4.0.1"
-      },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
@@ -10509,25 +6691,10 @@
       }
     },
     "inquirer": {
-      "version": "https://registry.npmjs.org/inquirer/-/inquirer-2.0.0.tgz",
-      "integrity": "sha512-ClW/liBHCfUD57ciSoxoq7fS9F3t1rvxxO5gRzdsDzfcJdKTyeMsVgRBQZkzcr8Nd2f4NIA9rm0qDl4ZXYZRUA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-2.0.0.tgz",
+      "integrity": "sha1-4TUWh7kNFQykA86qPO+x4wZb70s=",
       "dev": true,
-      "requires": {
-        "ansi-escapes": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-        "chalk": "1.1.3",
-        "cli-cursor": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-        "cli-width": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-        "external-editor": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
-        "figures": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-        "lodash": "4.17.4",
-        "mute-stream": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
-        "pinkie-promise": "2.0.1",
-        "run-async": "2.3.0",
-        "rx": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-        "string-width": "2.1.1",
-        "strip-ansi": "3.0.1",
-        "through": "2.3.8"
-      },
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
@@ -10546,31 +6713,21 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          },
           "dependencies": {
             "strip-ansi": {
               "version": "4.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "3.0.0"
-              }
+              "dev": true
             }
           }
         }
       }
     },
     "invariant": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-      "requires": {
-        "loose-envify": "1.3.1"
-      }
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA=="
     },
     "invert-kv": {
       "version": "1.0.0",
@@ -10578,9 +6735,9 @@
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
     "ipaddr.js": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz",
-      "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A=",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
+      "integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs=",
       "dev": true
     },
     "is-accessor-descriptor": {
@@ -10588,9 +6745,6 @@
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
       "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
       "dev": true,
-      "requires": {
-        "kind-of": "6.0.2"
-      },
       "dependencies": {
         "kind-of": {
           "version": "6.0.2",
@@ -10609,31 +6763,23 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-      "dev": true,
-      "requires": {
-        "binary-extensions": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz"
-      }
+      "dev": true
     },
     "is-buffer": {
-      "version": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-builtin-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "requires": {
-        "builtin-modules": "1.1.1"
-      }
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74="
     },
     "is-data-descriptor": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
       "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
       "dev": true,
-      "requires": {
-        "kind-of": "6.0.2"
-      },
       "dependencies": {
         "kind-of": {
           "version": "6.0.2",
@@ -10648,11 +6794,6 @@
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
       "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
       "dev": true,
-      "requires": {
-        "is-accessor-descriptor": "1.0.0",
-        "is-data-descriptor": "1.0.0",
-        "kind-of": "6.0.2"
-      },
       "dependencies": {
         "kind-of": {
           "version": "6.0.2",
@@ -10672,10 +6813,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "dev": true,
-      "requires": {
-        "is-primitive": "2.0.0"
-      }
+      "dev": true
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -10692,65 +6830,65 @@
     "is-finite": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "requires": {
-        "number-is-nan": "1.0.1"
-      }
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko="
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "requires": {
-        "number-is-nan": "1.0.1"
-      }
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
     },
     "is-git-url": {
-      "version": "https://registry.npmjs.org/is-git-url/-/is-git-url-1.0.0.tgz",
-      "integrity": "sha512-UCFta9F9rWFSavp9H3zHEHrARUfZbdJvmHKeEpds4BK3v7W2LdXoNypMtXXi5w5YBDEBCTYmbI+vsSwI8LYJaQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-git-url/-/is-git-url-1.0.0.tgz",
+      "integrity": "sha1-U/aEzRQyhbUsMkS05vKCU1J69ms=",
       "dev": true
     },
     "is-glob": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-      "dev": true,
-      "requires": {
-        "is-extglob": "1.0.0"
-      }
+      "dev": true
     },
     "is-integer": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.7.tgz",
-      "integrity": "sha1-a96Bqs3feLZZtmKdYpytxRqIbVw=",
-      "requires": {
-        "is-finite": "1.0.2"
-      }
+      "integrity": "sha1-a96Bqs3feLZZtmKdYpytxRqIbVw="
+    },
+    "is-my-ip-valid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ=="
     },
     "is-my-json-valid": {
-      "version": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz",
-      "integrity": "sha512-Q2khNw+oBlWuaYvEEHtKSw/pCxD2L5Rc1C+UQme9X6JdRDh7m5D7HkozA0qa3DUkQ6VzCnEm8mVIQPyIRkI5sQ==",
-      "requires": {
-        "generate-function": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-        "generate-object-property": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-        "jsonpointer": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-        "xtend": "4.0.1"
-      }
+      "version": "2.17.2",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
+      "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg=="
     },
     "is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-      "dev": true,
-      "requires": {
-        "kind-of": "3.2.2"
-      }
+      "dev": true
     },
     "is-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
+    },
+    "is-odd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
+      "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
+        }
+      }
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -10759,30 +6897,22 @@
       "dev": true
     },
     "is-path-in-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-      "dev": true,
-      "requires": {
-        "is-path-inside": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz"
-      }
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+      "dev": true
     },
     "is-path-inside": {
-      "version": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-      "integrity": "sha512-qhsCR/Esx4U4hg/9I19OVUAJkGWtjRYHMRgUMZE2TDdj+Ag+kttZanLupfddNyglzz50cUlmWzUaI37GDfNx/g==",
-      "dev": true,
-      "requires": {
-        "path-is-inside": "1.0.2"
-      }
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "dev": true
     },
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
-      "requires": {
-        "isobject": "3.0.1"
-      },
       "dependencies": {
         "isobject": {
           "version": "3.0.1",
@@ -10811,8 +6941,15 @@
       "dev": true
     },
     "is-property": {
-      "version": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+    },
+    "is-resolvable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "dev": true
     },
     "is-stream": {
       "version": "1.1.0",
@@ -10824,10 +6961,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/is-type/-/is-type-0.0.1.tgz",
       "integrity": "sha1-9lHYXDZdRJVdFKUdjXBh8/a0d5w=",
-      "dev": true,
-      "requires": {
-        "core-util-is": "1.0.2"
-      }
+      "dev": true
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -10865,10 +6999,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-      "dev": true,
-      "requires": {
-        "isarray": "1.0.0"
-      }
+      "dev": true
     },
     "isstream": {
       "version": "0.1.2",
@@ -10878,25 +7009,23 @@
     "istextorbinary": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.1.0.tgz",
-      "integrity": "sha1-2+0qb1G+L3R1to+JRlgRFBt1iHQ=",
-      "requires": {
-        "binaryextensions": "2.0.0",
-        "editions": "1.3.3",
-        "textextensions": "2.1.0"
-      }
+      "integrity": "sha1-2+0qb1G+L3R1to+JRlgRFBt1iHQ="
     },
     "jquery": {
-      "version": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
       "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg==",
       "dev": true
     },
     "js-base64": {
-      "version": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.2.tgz",
-      "integrity": "sha512-lLkz3IRPTNeATsKQGeltbzRK/5+bWsXBHfpZrxJAi4N30RtCtNA+rJznp4uR2+4OgkBsoeeFwONVLr4gzIVErQ=="
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
+      "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw=="
     },
     "js-reporters": {
-      "version": "https://registry.npmjs.org/js-reporters/-/js-reporters-1.2.1.tgz",
-      "integrity": "sha512-E4/TBelYYApx/lszChawx4+4MxEAZzL2hNYjQfHsIuu/vlYHkNRrlhTwaeABe5QhK546XmmAvqnCKHgawZs50g==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/js-reporters/-/js-reporters-1.2.1.tgz",
+      "integrity": "sha1-+IxgjjJKM3OpW8xFrTBeXJecRZs=",
       "dev": true
     },
     "js-tokens": {
@@ -10905,13 +7034,10 @@
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "js-yaml": {
-      "version": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+      "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
       "dev": true,
-      "requires": {
-        "argparse": "1.0.9",
-        "esprima": "4.0.0"
-      },
       "dependencies": {
         "esprima": {
           "version": "4.0.0",
@@ -10946,10 +7072,13 @@
     "json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "requires": {
-        "jsonify": "0.0.0"
-      }
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8="
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -10970,10 +7099,7 @@
     "jsonfile": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-      "requires": {
-        "graceful-fs": "4.1.11"
-      }
+      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug="
     },
     "jsonify": {
       "version": "0.0.0",
@@ -10981,18 +7107,14 @@
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "jsonpointer": {
-      "version": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha512-K7vR/jmvXsP04hvItAziqPeWmGceLWye9tkqbI+zFCvD4aDnL94BbGHggtQTfqRxbsgGWb4ospGQU8Rd7CEzPg=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
     },
     "jsprim": {
-      "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha512-4Dj8Rf+fQ+/Pn7C5qeEX02op1WfOss3PKTE9Nsop3Dx+6UPxlm1dr/og7o2cRa5hNN07CACr4NFzRLtj/rjWog==",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-        "json-schema": "0.2.3",
-        "verror": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz"
-      },
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -11004,19 +7126,13 @@
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "requires": {
-        "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz"
-      }
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ="
     },
     "klaw": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11"
-      }
+      "dev": true
     },
     "lazy-cache": {
       "version": "1.0.4",
@@ -11026,42 +7142,25 @@
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "requires": {
-        "invert-kv": "1.0.0"
-      }
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU="
     },
     "leek": {
       "version": "0.0.24",
       "resolved": "https://registry.npmjs.org/leek/-/leek-0.0.24.tgz",
       "integrity": "sha1-5ADlfw5g2O8r1NBo3EKKVDRdvNo=",
       "dev": true,
-      "requires": {
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-        "lodash.assign": "3.2.0",
-        "rsvp": "3.6.2"
-      },
       "dependencies": {
         "lodash.assign": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
           "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
-          "dev": true,
-          "requires": {
-            "lodash._baseassign": "3.2.0",
-            "lodash._createassigner": "3.1.1",
-            "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
-          }
+          "dev": true
         },
         "lodash.keys": {
-          "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-          "integrity": "sha512-CuBsapFjcubOGMn3VD+24HOAPxM79tH+V6ivJL3CHYjtrawauDJHUk//Yew9Hvc6e9rbCrURGk8z6PC+8WJBfQ==",
-          "dev": true,
-          "requires": {
-            "lodash._getnative": "3.9.1",
-            "lodash.isarguments": "3.1.0",
-            "lodash.isarray": "3.0.4"
-          }
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+          "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+          "dev": true
         }
       }
     },
@@ -11074,23 +7173,17 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
-      }
+      "dev": true
     },
     "linkify-it": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.0.3.tgz",
       "integrity": "sha1-2UpGSPmxwXnWT6lykSaL22zpQ08=",
-      "dev": true,
-      "requires": {
-        "uc.micro": "1.0.3"
-      }
+      "dev": true
     },
     "livereload-js": {
-      "version": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.3.0.tgz",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.3.0.tgz",
       "integrity": "sha512-j1R0/FeGa64Y+NmqfZhyoVRzcFlOZ8sNlKzHjh4VvLULFACZhn68XrX5DFg2FhMvSMJmROuFxRSa560ECWKBMg==",
       "dev": true
     },
@@ -11098,25 +7191,17 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
-      },
       "dependencies": {
         "strip-bom": {
-          "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g==",
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4="
         }
       }
     },
     "loader.js": {
-      "version": "https://registry.npmjs.org/loader.js/-/loader.js-4.6.0.tgz",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/loader.js/-/loader.js-4.6.0.tgz",
       "integrity": "sha512-NjAnzMq/BM2VlXA9er0Nx1Runocgi+hEU53ENhCtTx82GX6/l9NXwfIqg81om6QvmhUlv2zH+4R+N+wOoeXytQ==",
       "dev": true
     },
@@ -11125,10 +7210,6 @@
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
-      "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
-      },
       "dependencies": {
         "path-exists": {
           "version": "3.0.0",
@@ -11139,41 +7220,29 @@
       }
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
     },
     "lodash._baseassign": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "dev": true,
-      "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
-      },
       "dependencies": {
         "lodash.keys": {
-          "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-          "integrity": "sha512-CuBsapFjcubOGMn3VD+24HOAPxM79tH+V6ivJL3CHYjtrawauDJHUk//Yew9Hvc6e9rbCrURGk8z6PC+8WJBfQ==",
-          "dev": true,
-          "requires": {
-            "lodash._getnative": "3.9.1",
-            "lodash.isarguments": "3.1.0",
-            "lodash.isarray": "3.0.4"
-          }
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+          "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+          "dev": true
         }
       }
     },
     "lodash._basebind": {
-      "version": "https://registry.npmjs.org/lodash._basebind/-/lodash._basebind-2.3.0.tgz",
-      "integrity": "sha512-SHqM7YCuJ+BeGTs7lqpWnmdHEeF4MWxS3dksJctHFNxR81FXPOzA4bS5Vs5CpcGTkBpM8FCl+YEbQEblRw8ABg==",
-      "dev": true,
-      "requires": {
-        "lodash._basecreate": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.3.0.tgz",
-        "lodash._setbinddata": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.3.0.tgz",
-        "lodash.isobject": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.3.0.tgz"
-      }
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash._basebind/-/lodash._basebind-2.3.0.tgz",
+      "integrity": "sha1-K1vEUqDhBhQ7IYafIzvbWHQX0kg=",
+      "dev": true
     },
     "lodash._basecopy": {
       "version": "3.0.1",
@@ -11182,46 +7251,28 @@
       "dev": true
     },
     "lodash._basecreate": {
-      "version": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.3.0.tgz",
-      "integrity": "sha512-vwZaWldZwS2y9b99D8i9+WtgiZXbHKsBsMrpxJEqTsNW20NhJo5W8PBQkeQO9CmxuqEYn8UkMnfEM2MMT4cVrw==",
-      "dev": true,
-      "requires": {
-        "lodash._renative": "https://registry.npmjs.org/lodash._renative/-/lodash._renative-2.3.0.tgz",
-        "lodash.isobject": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.3.0.tgz",
-        "lodash.noop": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.3.0.tgz"
-      }
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.3.0.tgz",
+      "integrity": "sha1-m4ioak3P97fzxh2Dovz8BnHsneA=",
+      "dev": true
     },
     "lodash._basecreatecallback": {
-      "version": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.3.0.tgz",
-      "integrity": "sha512-Ev+pDzzfVfgbiucpXijconLGRBar7/+KNCf05kSnk4CmdDVhAy1RdbU9efCJ/o9GXI08JdUGwZ+5QJ3QX3kj0g==",
-      "dev": true,
-      "requires": {
-        "lodash._setbinddata": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.3.0.tgz",
-        "lodash.bind": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.3.0.tgz",
-        "lodash.identity": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.3.0.tgz",
-        "lodash.support": "https://registry.npmjs.org/lodash.support/-/lodash.support-2.3.0.tgz"
-      }
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.3.0.tgz",
+      "integrity": "sha1-N7KrF1kaM56YjbMln81GAZ16w2I=",
+      "dev": true
     },
     "lodash._basecreatewrapper": {
-      "version": "https://registry.npmjs.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.3.0.tgz",
-      "integrity": "sha512-YLycQ7k8AB9Wc1EOvLNxuRWcqipDkMXq2GCgnLWQR6qtgTb3gY3LELzEpnFshrEO4LOLs+R2EpcY+uCOZaLQ8Q==",
-      "dev": true,
-      "requires": {
-        "lodash._basecreate": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.3.0.tgz",
-        "lodash._setbinddata": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.3.0.tgz",
-        "lodash._slice": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.3.0.tgz",
-        "lodash.isobject": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.3.0.tgz"
-      }
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.3.0.tgz",
+      "integrity": "sha1-qgxhrZYETDkzN2ExSDqXWcNlEkc=",
+      "dev": true
     },
     "lodash._baseflatten": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
       "integrity": "sha1-B3D/gBMa9uNPO1EXlqe6UhTmX/c=",
-      "dev": true,
-      "requires": {
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
-      }
+      "dev": true
     },
     "lodash._bindcallback": {
       "version": "3.0.1",
@@ -11233,31 +7284,19 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
       "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
-      "dev": true,
-      "requires": {
-        "lodash._bindcallback": "3.0.1",
-        "lodash._isiterateecall": "3.0.9",
-        "lodash.restparam": "3.6.1"
-      }
+      "dev": true
     },
     "lodash._createwrapper": {
-      "version": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-2.3.0.tgz",
-      "integrity": "sha512-XjaI/rzg9W+WO4WJDQ+PRlHD5sAMJ1RhJLuT65cBxLCb1kIYs4U20jqvTDGAWyVT3c34GYiLd9AreHYuB/8yJA==",
-      "dev": true,
-      "requires": {
-        "lodash._basebind": "https://registry.npmjs.org/lodash._basebind/-/lodash._basebind-2.3.0.tgz",
-        "lodash._basecreatewrapper": "https://registry.npmjs.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.3.0.tgz",
-        "lodash.isfunction": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.3.0.tgz"
-      }
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-2.3.0.tgz",
+      "integrity": "sha1-0arhEC2t9EDo4G/BM6bt1/4UYHU=",
+      "dev": true
     },
     "lodash._escapehtmlchar": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.3.0.tgz",
       "integrity": "sha1-0D2mvYLu3zjcCltQPXQOzQ6JRZI=",
-      "dev": true,
-      "requires": {
-        "lodash._htmlescapes": "2.3.0"
-      }
+      "dev": true
     },
     "lodash._escapestringchar": {
       "version": "2.3.0",
@@ -11284,8 +7323,9 @@
       "dev": true
     },
     "lodash._objecttypes": {
-      "version": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.3.0.tgz",
-      "integrity": "sha512-jbA6QyHt9cw3BzvbWzIcnU3Z12jSneT6xBgz3Y782CJsN1tV5aTBKrFo2B4AkeHBNaxSrbPYZZpi1Lwj3xjdtg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.3.0.tgz",
+      "integrity": "sha1-aj6jmH3W7rgCGy1cnDA1Scwrrh4=",
       "dev": true
     },
     "lodash._reinterpolate": {
@@ -11295,40 +7335,33 @@
       "dev": true
     },
     "lodash._renative": {
-      "version": "https://registry.npmjs.org/lodash._renative/-/lodash._renative-2.3.0.tgz",
-      "integrity": "sha512-v44MRirqYqZGK/h5UKoVqXWF2L+LUiLTU+Ogu5rHRVWJUA1uWIlHaMpG8f/OA8j++BzPMQij9+erXHtgFcbuwg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash._renative/-/lodash._renative-2.3.0.tgz",
+      "integrity": "sha1-d9jt1M7SbdWXH54Vpfdy5OMX+9M=",
       "dev": true
     },
     "lodash._reunescapedhtml": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.3.0.tgz",
       "integrity": "sha1-25ILVax/P/glk5rOubosIxcT0k0=",
-      "dev": true,
-      "requires": {
-        "lodash._htmlescapes": "2.3.0",
-        "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.3.0.tgz"
-      }
+      "dev": true
     },
     "lodash._setbinddata": {
-      "version": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.3.0.tgz",
-      "integrity": "sha512-xMFfbF7dL+sFtrdE49uHFmfpBAEwlFtfgMp86nQRlAF6aizYL+3MTbnYMKJSkP1W501PhsgiBED5kBbZd8kR2g==",
-      "dev": true,
-      "requires": {
-        "lodash._renative": "https://registry.npmjs.org/lodash._renative/-/lodash._renative-2.3.0.tgz",
-        "lodash.noop": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.3.0.tgz"
-      }
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.3.0.tgz",
+      "integrity": "sha1-5WEEkKzRMnfVmFjZW18nJ/FQjwQ=",
+      "dev": true
     },
     "lodash._shimkeys": {
-      "version": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.3.0.tgz",
-      "integrity": "sha512-9Iuyi7TiWMGa/9+2rqEE+Zwye4b/U2w7Saw6UX1h6Xs88mEER+uz9FZcEBPKMVKsad9Pw5GNAcIBRnW2jNpneQ==",
-      "dev": true,
-      "requires": {
-        "lodash._objecttypes": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.3.0.tgz"
-      }
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.3.0.tgz",
+      "integrity": "sha1-YR+TFJ4+bHIQlrSHae8pU3rai6k=",
+      "dev": true
     },
     "lodash._slice": {
-      "version": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.3.0.tgz",
-      "integrity": "sha512-7C61GhzRUv36gTafr+RIb+AomCAYsSATEoK4OP0VkNBcwvsM022Z22AVgqjjzikeNO1U29LzsJZDvLbiNPUYvA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.3.0.tgz",
+      "integrity": "sha1-FHGYEyhZly5GgMoppZkshVZpqlw=",
       "dev": true
     },
     "lodash.assign": {
@@ -11343,14 +7376,10 @@
       "dev": true
     },
     "lodash.bind": {
-      "version": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.3.0.tgz",
-      "integrity": "sha512-goakyOo+FMN8lttMPnZ0UNlr5RlzX4IrUXyTJPT2A0tGCMXySupond9wzvDqTvVmYTcQjIKGrj8naJDS2xWAlQ==",
-      "dev": true,
-      "requires": {
-        "lodash._createwrapper": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-2.3.0.tgz",
-        "lodash._renative": "https://registry.npmjs.org/lodash._renative/-/lodash._renative-2.3.0.tgz",
-        "lodash._slice": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.3.0.tgz"
-      }
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.3.0.tgz",
+      "integrity": "sha1-wqjhi2jl7MFS4rFoJmEW/qWwFsw=",
+      "dev": true
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
@@ -11361,20 +7390,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-3.1.1.tgz",
       "integrity": "sha1-gSIRw3ipTMKdWqTjNGzwv846ffU=",
-      "dev": true,
-      "requires": {
-        "lodash._getnative": "3.9.1"
-      }
+      "dev": true
     },
     "lodash.defaults": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.3.0.tgz",
-      "integrity": "sha1-qDKwAfE487uXIcKBmip8xa4h7SU=",
-      "dev": true,
-      "requires": {
-        "lodash._objecttypes": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.3.0.tgz",
-        "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.3.0.tgz"
-      }
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
     },
     "lodash.defaultsdeep": {
       "version": "4.6.0",
@@ -11386,12 +7407,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.3.0.tgz",
       "integrity": "sha1-hEw4xY+EThNi6+lnJhWbYs9fKlg=",
-      "dev": true,
-      "requires": {
-        "lodash._escapehtmlchar": "2.3.0",
-        "lodash._reunescapedhtml": "2.3.0",
-        "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.3.0.tgz"
-      }
+      "dev": true
     },
     "lodash.find": {
       "version": "4.6.0",
@@ -11403,34 +7419,24 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-3.0.2.tgz",
       "integrity": "sha1-3hz1d1j49EeTGdNcPpzGDEUBk4w=",
-      "dev": true,
-      "requires": {
-        "lodash._baseflatten": "3.1.4",
-        "lodash._isiterateecall": "3.0.9"
-      }
+      "dev": true
     },
     "lodash.foreach": {
-      "version": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-2.3.0.tgz",
-      "integrity": "sha512-yLnyptVRJd0//AbGp480grgQG9iaDIV5uOgSbpurRy1dYybPbjNTLQ3FyLEQ84buVLPG7jyaiyvpzgfOutRB3Q==",
-      "dev": true,
-      "requires": {
-        "lodash._basecreatecallback": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.3.0.tgz",
-        "lodash.forown": "https://registry.npmjs.org/lodash.forown/-/lodash.forown-2.3.0.tgz"
-      }
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-2.3.0.tgz",
+      "integrity": "sha1-CDQEyR6EbudyRf3512UZxosq8Wg=",
+      "dev": true
     },
     "lodash.forown": {
-      "version": "https://registry.npmjs.org/lodash.forown/-/lodash.forown-2.3.0.tgz",
-      "integrity": "sha512-dUnCsuQTtq3Y7bxPNoEEqjJjPL2ftLtcz2PTeRKvhbpdM514AvnqCjewHGsm/W+dwspIwa14KoWEZeizJ7smxA==",
-      "dev": true,
-      "requires": {
-        "lodash._basecreatecallback": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.3.0.tgz",
-        "lodash._objecttypes": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.3.0.tgz",
-        "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.3.0.tgz"
-      }
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.forown/-/lodash.forown-2.3.0.tgz",
+      "integrity": "sha1-JPtKr4ANRfwtxgv+w84EyDajrX8=",
+      "dev": true
     },
     "lodash.identity": {
-      "version": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.3.0.tgz",
-      "integrity": "sha512-NYJ2r2cwy3tkx/saqbIZEX6oQUzjWTnGRu7d/zmBjMCZos3eHBxCpbvWFWSetv8jFVrptsp6EbWjzNgBKhUoOA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.3.0.tgz",
+      "integrity": "sha1-awGiEMlIU1XCqRO0i2cRIZoXPe0=",
       "dev": true
     },
     "lodash.isarguments": {
@@ -11446,42 +7452,38 @@
       "dev": true
     },
     "lodash.isfunction": {
-      "version": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.3.0.tgz",
-      "integrity": "sha512-X5lteBYlCrVO7Qc00fxP8W90fzRp6Ax9XcHANmU3OsZHdSyIVZ9ZlX5QTTpRq8aGY+9I5Rmd0UTzTIIyWPugEQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.3.0.tgz",
+      "integrity": "sha1-aylz5HpkfPEucNZ2rqE2Q3BuUmc=",
       "dev": true
     },
     "lodash.isobject": {
-      "version": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.3.0.tgz",
-      "integrity": "sha512-jo1pfV61C4TE8BfEzqaHj6EIKiSkFANJrB6yscwuCJMSRw5tbqjk4Gv7nJzk4Z6nFKobZjGZ8Qd41vmnwgeQqQ==",
-      "dev": true,
-      "requires": {
-        "lodash._objecttypes": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.3.0.tgz"
-      }
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.3.0.tgz",
+      "integrity": "sha1-LhbT/Fg9qYMZaJU/LY5tc0NPZ5k=",
+      "dev": true
     },
     "lodash.keys": {
-      "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.3.0.tgz",
-      "integrity": "sha512-c0UW0ffqMxSCtoVbmVt2lERJLkEqgoOn2ejPsWXzr0ZrqRbl3uruGgwHzhtqXxi6K/ei3Ey7zimOqSwXgzazPg==",
-      "dev": true,
-      "requires": {
-        "lodash._renative": "https://registry.npmjs.org/lodash._renative/-/lodash._renative-2.3.0.tgz",
-        "lodash._shimkeys": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.3.0.tgz",
-        "lodash.isobject": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.3.0.tgz"
-      }
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.3.0.tgz",
+      "integrity": "sha1-s1D0+Syqn0WkouzwGEVM8vKK4lM=",
+      "dev": true
     },
     "lodash.merge": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
-      "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU=",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
       "dev": true
     },
     "lodash.mergewith": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz",
-      "integrity": "sha1-FQzwoWeR9ZA7iJHqsVRgknS96lU="
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
+      "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ=="
     },
     "lodash.noop": {
-      "version": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.3.0.tgz",
-      "integrity": "sha512-NpSm8HRm1WkBBWHUveDukLF4Kfb5P5E3fjHc9Qre9A11nNubozLWD2wH3UBTZbu+KSuX8aSUvy9b+PUyEceJ8g==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.3.0.tgz",
+      "integrity": "sha1-MFnWKNUbv5N80qC2/Dp/ISpmnCw=",
       "dev": true
     },
     "lodash.omit": {
@@ -11497,35 +7499,28 @@
       "dev": true
     },
     "lodash.support": {
-      "version": "https://registry.npmjs.org/lodash.support/-/lodash.support-2.3.0.tgz",
-      "integrity": "sha512-etc7VWbB0U3Iya8ixj2xy4sDBN3jvPX7ODi8iXtn4KkkjNpdngrdc7Vlt5jub/Vgqx6/dWtp7Ml9awhCQPYKGQ==",
-      "dev": true,
-      "requires": {
-        "lodash._renative": "https://registry.npmjs.org/lodash._renative/-/lodash._renative-2.3.0.tgz"
-      }
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.support/-/lodash.support-2.3.0.tgz",
+      "integrity": "sha1-fq8DivTw1qq3drRKptz8gDNMm/0=",
+      "dev": true
     },
     "lodash.template": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
       "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
       "dev": true,
-      "requires": {
-        "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-        "lodash.templatesettings": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz"
-      },
       "dependencies": {
         "lodash._reinterpolate": {
-          "version": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-          "integrity": "sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+          "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
           "dev": true
         },
         "lodash.templatesettings": {
-          "version": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
-          "integrity": "sha512-UYY4Eo4BJ1E3WDldMjTqqnRBOEhcOqEz8sD1CkxOX2jsOC2qrj4WNt/3hBgB8pg9Ta6T5fpuKE0C+HfymYdT9g==",
-          "dev": true,
-          "requires": {
-            "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
-          }
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
+          "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
+          "dev": true
         }
       }
     },
@@ -11533,11 +7528,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.3.0.tgz",
       "integrity": "sha1-MD0TLDQnEAQNWhjvqi1XL9A/jNw=",
-      "dev": true,
-      "requires": {
-        "lodash._reinterpolate": "2.3.0",
-        "lodash.escape": "2.3.0"
-      }
+      "dev": true
     },
     "lodash.uniq": {
       "version": "4.5.0",
@@ -11555,18 +7546,32 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.3.0.tgz",
       "integrity": "sha1-ypb75gogsLDsK6K6X8anZb0Uo7o=",
-      "dev": true,
-      "requires": {
-        "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.3.0.tgz"
-      }
+      "dev": true
     },
     "log-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
-      "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
       "dev": true,
-      "requires": {
-        "chalk": "1.1.3"
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "dev": true
+        }
       }
     },
     "longest": {
@@ -11577,36 +7582,23 @@
     "loose-envify": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-      "requires": {
-        "js-tokens": "3.0.2"
-      }
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg="
     },
     "loud-rejection": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-      "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
-      }
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8="
     },
     "lru-cache": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-      "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
-      }
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
+      "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ=="
     },
     "make-dir": {
-      "version": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
-      "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
+      "integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
       "dev": true,
-      "requires": {
-        "pify": "3.0.0"
-      },
       "dependencies": {
         "pify": {
           "version": "3.0.0",
@@ -11620,10 +7612,7 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
-      "dev": true,
-      "requires": {
-        "tmpl": "1.0.4"
-      }
+      "dev": true
     },
     "map-cache": {
       "version": "0.2.2",
@@ -11640,74 +7629,38 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
-      "dev": true,
-      "requires": {
-        "object-visit": "1.0.1"
-      }
+      "dev": true
     },
     "markdown-it": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.0.tgz",
-      "integrity": "sha1-4kAIgb8XH3AY7RvZ2kQdrIr2MG0=",
-      "dev": true,
-      "requires": {
-        "argparse": "1.0.9",
-        "entities": "1.1.1",
-        "linkify-it": "2.0.3",
-        "mdurl": "1.0.1",
-        "uc.micro": "1.0.3"
-      }
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.1.tgz",
+      "integrity": "sha512-CzzqSSNkFRUf9vlWvhK1awpJreMRqdCrBvZ8DIoDWTOkESMIF741UPAhuAmbyWmdiFPA6WARNhnu2M6Nrhwa+A==",
+      "dev": true
     },
     "markdown-it-terminal": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/markdown-it-terminal/-/markdown-it-terminal-0.1.0.tgz",
       "integrity": "sha1-VFq9jdAcPWI1O/zqcdtYC1HSK9k=",
       "dev": true,
-      "requires": {
-        "ansi-styles": "3.2.0",
-        "cardinal": "1.0.0",
-        "cli-table": "0.3.1",
-        "lodash.merge": "4.6.0",
-        "markdown-it": "8.4.0"
-      },
       "dependencies": {
         "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          },
-          "dependencies": {
-            "color-convert": {
-              "version": "1.9.1",
-              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-              "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-              "dev": true,
-              "requires": {
-                "color-name": "1.1.3"
-              }
-            }
-          }
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true
         }
       }
     },
     "matcher-collection": {
-      "version": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.5.tgz",
-      "integrity": "sha512-nUCmzKipcJEwYsBVAFh5P+d7JBuhJaW1xs85Hara9xuMLqtCVUrW6DSC0JVIkluxEH2W45nPBM/wjHtBXa/tYA==",
-      "requires": {
-        "minimatch": "3.0.4"
-      }
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.5.tgz",
+      "integrity": "sha512-nUCmzKipcJEwYsBVAFh5P+d7JBuhJaW1xs85Hara9xuMLqtCVUrW6DSC0JVIkluxEH2W45nPBM/wjHtBXa/tYA=="
     },
     "md5-hex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-2.0.0.tgz",
       "integrity": "sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=",
-      "dev": true,
-      "requires": {
-        "md5-o-matic": "0.1.1"
-      }
+      "dev": true
     },
     "md5-o-matic": {
       "version": "0.1.1",
@@ -11728,13 +7681,10 @@
       "dev": true
     },
     "memory-streams": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/memory-streams/-/memory-streams-0.1.2.tgz",
-      "integrity": "sha1-Jz/3d6tg/sWZsRY1UlUoLMosUMI=",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/memory-streams/-/memory-streams-0.1.3.tgz",
+      "integrity": "sha512-qVQ/CjkMyMInPaaRMrwWNDvf6boRZXaT/DbQeMYcCWuXPEBf1v8qChOc9OlEVQp2uOvRXa1Qu30fLmKhY6NipA==",
       "dev": true,
-      "requires": {
-        "readable-stream": "1.0.34"
-      },
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
@@ -11746,13 +7696,7 @@
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
+          "dev": true
         },
         "string_decoder": {
           "version": "0.10.31",
@@ -11766,18 +7710,6 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-      "requires": {
-        "camelcase-keys": "2.1.0",
-        "decamelize": "1.2.0",
-        "loud-rejection": "1.6.0",
-        "map-obj": "1.0.1",
-        "minimist": "1.2.0",
-        "normalize-package-data": "2.4.0",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "redent": "1.0.0",
-        "trim-newlines": "1.0.0"
-      },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
@@ -11789,7 +7721,8 @@
     "merge": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
+      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
+      "dev": true
     },
     "merge-descriptors": {
       "version": "1.0.1",
@@ -11800,15 +7733,7 @@
     "merge-trees": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-1.0.1.tgz",
-      "integrity": "sha1-zL5nRWl4f53vF/1G5lJfVwC70j4=",
-      "requires": {
-        "can-symlink": "1.0.0",
-        "fs-tree-diff": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.7.tgz",
-        "heimdalljs": "0.2.5",
-        "heimdalljs-logger": "0.1.9",
-        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-        "symlink-or-copy": "1.1.8"
-      }
+      "integrity": "sha1-zL5nRWl4f53vF/1G5lJfVwC70j4="
     },
     "methods": {
       "version": "1.1.2",
@@ -11820,52 +7745,34 @@
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-      "dev": true,
-      "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz"
-      }
+      "dev": true
     },
     "mime": {
-      "version": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
       "dev": true
     },
     "mime-db": {
-      "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-      "integrity": "sha512-SUaL89ROHF5P6cwrhLxE1Xmk60cFcctcJl3zwMeQWcoQzt0Al/X8qxUz2gi19NECqYspzbYpAJryIRnLcjp20g=="
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
     },
     "mime-types": {
-      "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-      "integrity": "sha512-rOFZoFAbaupSpzARUe5CU1P9mwfX+lIFAuj0soNsEZEnrHu6LZNyV7/FClEB/oF9A1o5KStlumRjW6D4Q2FRCA==",
-      "requires": {
-        "mime-db": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz"
-      }
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ=="
     },
     "mimic-fn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "requires": {
-        "brace-expansion": "1.1.8"
-      }
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA=="
     },
     "minimist": {
       "version": "0.0.8",
@@ -11877,29 +7784,19 @@
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "dev": true,
-      "requires": {
-        "for-in": "1.0.2",
-        "is-extendable": "1.0.1"
-      },
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-          "dev": true,
-          "requires": {
-            "is-plain-object": "2.0.4"
-          }
+          "dev": true
         }
       }
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "requires": {
-        "minimist": "0.0.8"
-      }
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM="
     },
     "mktemp": {
       "version": "0.4.0",
@@ -11907,28 +7804,20 @@
       "integrity": "sha1-bQUVYRyKjITkhKogABKbmOmB/ws="
     },
     "moment": {
-      "version": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
-      "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.0.tgz",
+      "integrity": "sha512-1muXCh8jb1N/gHRbn9VDUBr0GYb8A/aVcHlII9QSB68a50spqEVLIGN6KVmCOnSvJrUhC0edGgKU5ofnGXdYdg=="
     },
     "moment-timezone": {
-      "version": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.14.tgz",
-      "integrity": "sha512-4RkNPVuQ/ClAXqd3T+tkBy85tEUxnNNIaG4hbviFp7vZ2hRY0mjHGRIWG/NdkUzSaH36nchdBXyvPwrODjPzUA==",
-      "requires": {
-        "moment": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz"
-      }
+      "version": "0.5.14",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.14.tgz",
+      "integrity": "sha1-TrOP+VOLgBCLpGekWPPtQmjM/LE="
     },
     "morgan": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.0.tgz",
       "integrity": "sha1-0B+mxlhZt2/PMbPLU6OCGjEdgFE=",
-      "dev": true,
-      "requires": {
-        "basic-auth": "2.0.0",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-        "depd": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-        "on-finished": "2.3.0",
-        "on-headers": "1.0.1"
-      }
+      "dev": true
     },
     "mout": {
       "version": "1.1.0",
@@ -11948,13 +7837,47 @@
       "dev": true
     },
     "mute-stream": {
-      "version": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
-      "integrity": "sha512-m0kBTDLF/0lgzCsPVmJSKM5xkLNX7ZAB0Q+n2DP37JMIRPVC2R4c3BdO6x++bXFKftbhvSfKgwxAexME+BRDRw==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
+      "integrity": "sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s=",
       "dev": true
     },
     "nan": {
-      "version": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-      "integrity": "sha512-kBTsZNixwSmgVRl1nIVCkQzqRmosFpnY/pLPYo8xC7Mu9ehnKkbrMsM4xb889UafRGLqJ58hKZp+Dn4XVP9Bpg=="
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+    },
+    "nanomatch": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
+      "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+      "dev": true,
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "is-windows": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+          "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
+      }
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -11972,31 +7895,12 @@
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "dev": true,
-      "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
-      }
+      "dev": true
     },
     "node-gyp": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
       "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
-      "requires": {
-        "fstream": "1.0.11",
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "npmlog": "4.1.2",
-        "osenv": "0.1.4",
-        "request": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-        "semver": "5.3.0",
-        "tar": "2.2.1",
-        "which": "https://registry.npmjs.org/which/-/which-1.3.0.tgz"
-      },
       "dependencies": {
         "semver": {
           "version": "5.3.0",
@@ -12018,98 +7922,48 @@
       "dev": true
     },
     "node-notifier": {
-      "version": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
       "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
-      "dev": true,
-      "requires": {
-        "growly": "1.3.0",
-        "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-        "shellwords": "0.1.1",
-        "which": "https://registry.npmjs.org/which/-/which-1.3.0.tgz"
-      }
+      "dev": true
     },
     "node-sass": {
-      "version": "https://registry.npmjs.org/node-sass/-/node-sass-4.7.2.tgz",
-      "integrity": "sha512-CaV+wLqZ7//Jdom5aUFCpGNoECd7BbNhjuwdsX/LkXBrHl8eb1Wjw4HvWqcFvhr5KuNgAk8i/myf/MQ1YYeroA==",
-      "requires": {
-        "async-foreach": "0.1.3",
-        "chalk": "1.1.3",
-        "cross-spawn": "3.0.1",
-        "gaze": "1.1.2",
-        "get-stdin": "4.0.1",
-        "glob": "7.1.2",
-        "in-publish": "2.0.0",
-        "lodash.assign": "4.2.0",
-        "lodash.clonedeep": "4.5.0",
-        "lodash.mergewith": "4.6.0",
-        "meow": "3.7.0",
-        "mkdirp": "0.5.1",
-        "nan": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-        "node-gyp": "3.6.2",
-        "npmlog": "4.1.2",
-        "request": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-        "sass-graph": "2.2.4",
-        "stdout-stream": "1.4.0",
-        "true-case-path": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.2.tgz"
-      }
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.8.3.tgz",
+      "integrity": "sha512-tfFWhUsCk/Y19zarDcPo5xpj+IW3qCfOjVdHtYeG6S1CKbQOh1zqylnQK6cV3z9k80yxAnFX9Y+a9+XysDhhfg=="
     },
     "nopt": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-      "requires": {
-        "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz"
-      }
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k="
     },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-      "requires": {
-        "hosted-git-info": "2.5.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-        "validate-npm-package-license": "3.0.1"
-      }
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw=="
     },
     "normalize-path": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dev": true,
-      "requires": {
-        "remove-trailing-separator": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz"
-      }
+      "dev": true
     },
     "npm-package-arg": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.2.1.tgz",
       "integrity": "sha1-WTMD/eqF98Qid18X+et2cPaA4+w=",
-      "dev": true,
-      "requires": {
-        "hosted-git-info": "2.5.0",
-        "semver": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
-      }
+      "dev": true
     },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "dev": true,
-      "requires": {
-        "path-key": "2.0.1"
-      }
+      "dev": true
     },
     "npmlog": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-      "requires": {
-        "are-we-there-yet": "1.1.4",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
-      }
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg=="
     },
     "number-is-nan": {
       "version": "1.0.1",
@@ -12137,49 +7991,30 @@
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
-      "requires": {
-        "copy-descriptor": "0.1.1",
-        "define-property": "0.2.5",
-        "kind-of": "3.2.2"
-      },
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true,
-          "requires": {
-            "is-descriptor": "0.1.6"
-          }
+          "dev": true
         },
         "is-accessor-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          }
+          "dev": true
         },
         "is-data-descriptor": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          }
+          "dev": true
         },
         "is-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
-          },
           "dependencies": {
             "kind-of": {
               "version": "5.1.0",
@@ -12196,9 +8031,6 @@
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
-      "requires": {
-        "isobject": "3.0.1"
-      },
       "dependencies": {
         "isobject": {
           "version": "3.0.1",
@@ -12212,20 +8044,13 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "dev": true,
-      "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
-      }
+      "dev": true
     },
     "object.pick": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
-      "requires": {
-        "isobject": "3.0.1"
-      },
       "dependencies": {
         "isobject": {
           "version": "3.0.1",
@@ -12239,10 +8064,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-      "dev": true,
-      "requires": {
-        "ee-first": "1.1.1"
-      }
+      "dev": true
     },
     "on-headers": {
       "version": "1.0.1",
@@ -12253,39 +8075,25 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "requires": {
-        "wrappy": "1.0.2"
-      }
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
     },
     "onetime": {
-      "version": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-      "integrity": "sha512-GZ+g4jayMqzCRMgB2sol7GiCLjKfS1PINkjmx8spcKce1LiVqcbQreXwqs2YAFXC6R03VIG28ZS31t8M866v6A==",
+      "version": "1.1.0",
+      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
-      "requires": {
-        "minimist": "0.0.8",
-        "wordwrap": "0.0.2"
-      }
+      "dev": true
     },
     "optionator": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
-      "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
-      },
       "dependencies": {
         "wordwrap": {
           "version": "1.0.0",
@@ -12302,44 +8110,58 @@
       "dev": true
     },
     "ora": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-1.3.0.tgz",
-      "integrity": "sha1-gAeN0rkqk0r2ajrXKluRBpTt5Ro=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-2.0.0.tgz",
+      "integrity": "sha512-g+IR0nMUXq1k4nE3gkENbN4wkF0XsVZFyxznTF6CdmwQ9qeTGONGpSR9LM5//1l0TVvJoJF3MkMtJp6slUsWFg==",
       "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "cli-cursor": "2.1.0",
-        "cli-spinners": "1.1.0",
-        "log-symbols": "1.0.2"
-      },
       "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+          "dev": true
+        },
         "cli-cursor": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
           "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-          "dev": true,
-          "requires": {
-            "restore-cursor": "2.0.0"
-          }
+          "dev": true
         },
         "onetime": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
           "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "1.1.0"
-          }
+          "dev": true
         },
         "restore-cursor": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
           "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-          "dev": true,
-          "requires": {
-            "onetime": "2.0.1",
-            "signal-exit": "3.0.2"
-          }
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "dev": true
         }
       }
     },
@@ -12351,14 +8173,12 @@
     "os-locale": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-      "requires": {
-        "lcid": "1.0.0"
-      }
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk="
     },
     "os-shim": {
-      "version": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
-      "integrity": "sha512-jd0cvB8qQ5uVt0lvCIexBaROw1KyKm5sbulg2fWOHjETisuCzWyt+eTZKEMs8v6HwzoGs8xik26jg7eCM6pS+A==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
+      "integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc=",
       "dev": true
     },
     "os-tmpdir": {
@@ -12367,23 +8187,14 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "osenv": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-      "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
-      "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
-      }
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g=="
     },
     "output-file-sync": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
-      "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "mkdirp": "0.5.1",
-        "object-assign": "4.1.1"
-      }
+      "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY="
     },
     "p-finally": {
       "version": "1.0.0",
@@ -12392,46 +8203,33 @@
       "dev": true
     },
     "p-limit": {
-      "version": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
       "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
-      "dev": true,
-      "requires": {
-        "p-try": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz"
-      }
+      "dev": true
     },
     "p-locate": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-      "dev": true,
-      "requires": {
-        "p-limit": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz"
-      }
+      "dev": true
     },
     "p-try": {
-      "version": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
     },
     "parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "dev": true,
-      "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
-      }
+      "dev": true
     },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "requires": {
-        "error-ex": "1.3.1"
-      }
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck="
     },
     "parse-passwd": {
       "version": "1.0.0",
@@ -12443,28 +8241,19 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.3.tgz",
       "integrity": "sha1-q343WfIJ7OmUN5c/fQ8fZK4OZKs=",
-      "dev": true,
-      "requires": {
-        "better-assert": "1.0.2"
-      }
+      "dev": true
     },
     "parseqs": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
-      "dev": true,
-      "requires": {
-        "better-assert": "1.0.2"
-      }
+      "dev": true
     },
     "parseuri": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
-      "dev": true,
-      "requires": {
-        "better-assert": "1.0.2"
-      }
+      "dev": true
     },
     "parseurl": {
       "version": "1.3.2",
@@ -12479,12 +8268,10 @@
       "dev": true
     },
     "passwd-user": {
-      "version": "https://registry.npmjs.org/passwd-user/-/passwd-user-1.2.1.tgz",
-      "integrity": "sha512-0Ha7cu6j5fjh1BZuh0dutqkv350qp6iJvFQuKy8C4cAW/hDscAOWsVv0K7PoT2FCofN8n/7LDqKbTW3kwScOUQ==",
-      "dev": true,
-      "requires": {
-        "exec-file-sync": "https://registry.npmjs.org/exec-file-sync/-/exec-file-sync-2.0.2.tgz"
-      }
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/passwd-user/-/passwd-user-1.2.1.tgz",
+      "integrity": "sha1-oBpdxjnvAH3FY2S4F4VpCArTp7g=",
+      "dev": true
     },
     "path-exists": {
       "version": "1.0.0",
@@ -12527,12 +8314,7 @@
     "path-type": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
-      }
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE="
     },
     "pify": {
       "version": "2.3.0",
@@ -12547,21 +8329,19 @@
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "requires": {
-        "pinkie": "2.0.4"
-      }
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o="
+    },
+    "pluralize": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "dev": true
     },
     "portfinder": {
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
       "integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
       "dev": true,
-      "requires": {
-        "async": "1.5.2",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-        "mkdirp": "0.5.1"
-      },
       "dependencies": {
         "async": {
           "version": "1.5.2",
@@ -12596,40 +8376,37 @@
       "dev": true
     },
     "private": {
-      "version": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
       "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
     },
     "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "process-relative-require": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/process-relative-require/-/process-relative-require-1.0.0.tgz",
       "integrity": "sha1-FZDfz1uPKYO6U+OYRGtoJAtMxoo=",
-      "dev": true,
-      "requires": {
-        "node-modules-path": "1.0.1"
-      }
+      "dev": true
+    },
+    "progress": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+      "dev": true
     },
     "promise-map-series": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.3.tgz",
-      "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
-      "requires": {
-        "rsvp": "3.6.2"
-      }
+      "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc="
     },
     "proxy-addr": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
-      "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
-      "dev": true,
-      "requires": {
-        "forwarded": "0.1.2",
-        "ipaddr.js": "1.5.2"
-      }
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
+      "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
+      "dev": true
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -12642,37 +8419,25 @@
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "q": {
-      "version": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "qs": {
-      "version": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-      "integrity": "sha512-H7Es34wXu+JjuD3QLwVgqtVU1nisFhwxYdYCYSFzWyP5/S4s8DtJ6rbVWdHVat/UPYiV36wxYmL7rPbLQJrX7g=="
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+      "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw="
     },
     "quick-temp": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.8.tgz",
-      "integrity": "sha1-urAqJCq4+w3XWKPJd2sy+aXZRAg=",
-      "requires": {
-        "mktemp": "0.4.0",
-        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-        "underscore.string": "3.3.4"
-      }
+      "integrity": "sha1-urAqJCq4+w3XWKPJd2sy+aXZRAg="
     },
     "qunit": {
-      "version": "https://registry.npmjs.org/qunit/-/qunit-2.5.0.tgz",
-      "integrity": "sha512-GVvRr8ISFMs4SkTWFsaUzMBs7QEuiXVT4orlFgyHkmeXO1ijlDkhW6ecPri4urXiE4BUXEULJAtFlV1MWgg4Uw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/qunit/-/qunit-2.6.0.tgz",
+      "integrity": "sha512-TlkujgRlTH/hF55MA5gtcRsU/F8Ge/RqE370tSuVEPywdQ1hRPP1n5zZas5YVxUSbAkDNdoOOJFiHFU8UyOMzw==",
       "dev": true,
-      "requires": {
-        "chokidar": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-        "commander": "2.12.2",
-        "exists-stat": "1.0.0",
-        "findup-sync": "2.0.0",
-        "js-reporters": "https://registry.npmjs.org/js-reporters/-/js-reporters-1.2.1.tgz",
-        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-        "shelljs": "https://registry.npmjs.org/shelljs/-/shelljs-0.2.6.tgz",
-        "walk-sync": "0.3.2"
-      },
       "dependencies": {
         "arr-diff": {
           "version": "4.0.0",
@@ -12691,38 +8456,18 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.1.tgz",
           "integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
           "dev": true,
-          "requires": {
-            "arr-flatten": "1.1.0",
-            "array-unique": "0.3.2",
-            "define-property": "1.0.0",
-            "extend-shallow": "2.0.1",
-            "fill-range": "4.0.0",
-            "isobject": "3.0.1",
-            "kind-of": "6.0.2",
-            "repeat-element": "1.1.2",
-            "snapdragon": "0.8.1",
-            "snapdragon-node": "2.1.1",
-            "split-string": "3.1.0",
-            "to-regex": "3.0.1"
-          },
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-              "dev": true,
-              "requires": {
-                "is-descriptor": "1.0.2"
-              }
+              "dev": true
             },
             "extend-shallow": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "0.1.1"
-              }
+              "dev": true
             }
           }
         },
@@ -12743,44 +8488,24 @@
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
-          "requires": {
-            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "posix-character-classes": "0.1.1",
-            "regex-not": "1.0.0",
-            "snapdragon": "0.8.1",
-            "to-regex": "3.0.1"
-          },
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-              "dev": true,
-              "requires": {
-                "is-descriptor": "0.1.6"
-              }
+              "dev": true
             },
             "extend-shallow": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "0.1.1"
-              }
+              "dev": true
             },
             "is-descriptor": {
               "version": "0.1.6",
               "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
-              }
+              "dev": true
             },
             "kind-of": {
               "version": "5.1.0",
@@ -12794,44 +8519,25 @@
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
           "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
-          "dev": true,
-          "requires": {
-            "homedir-polyfill": "1.0.1"
-          }
+          "dev": true
         },
         "extglob": {
           "version": "2.0.4",
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
-          "requires": {
-            "array-unique": "0.3.2",
-            "define-property": "1.0.0",
-            "expand-brackets": "2.1.4",
-            "extend-shallow": "2.0.1",
-            "fragment-cache": "0.2.1",
-            "regex-not": "1.0.0",
-            "snapdragon": "0.8.1",
-            "to-regex": "3.0.1"
-          },
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-              "dev": true,
-              "requires": {
-                "is-descriptor": "1.0.2"
-              }
+              "dev": true
             },
             "extend-shallow": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "0.1.1"
-              }
+              "dev": true
             }
           }
         },
@@ -12840,21 +8546,12 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
-          "requires": {
-            "extend-shallow": "2.0.1",
-            "is-number": "3.0.0",
-            "repeat-string": "1.6.1",
-            "to-regex-range": "2.1.1"
-          },
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "0.1.1"
-              }
+              "dev": true
             }
           }
         },
@@ -12862,55 +8559,31 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
           "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
-          "dev": true,
-          "requires": {
-            "detect-file": "1.0.0",
-            "is-glob": "3.1.0",
-            "micromatch": "3.1.9",
-            "resolve-dir": "1.0.1"
-          }
+          "dev": true
         },
         "global-modules": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
           "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
-          "dev": true,
-          "requires": {
-            "global-prefix": "1.0.2",
-            "is-windows": "1.0.2",
-            "resolve-dir": "1.0.1"
-          }
+          "dev": true
         },
         "global-prefix": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
           "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
-          "dev": true,
-          "requires": {
-            "expand-tilde": "2.0.2",
-            "homedir-polyfill": "1.0.1",
-            "ini": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-            "is-windows": "1.0.2",
-            "which": "https://registry.npmjs.org/which/-/which-1.3.0.tgz"
-          }
+          "dev": true
         },
         "is-accessor-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz"
-              }
+              "dev": true
             }
           }
         },
@@ -12919,18 +8592,12 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz"
-              }
+              "dev": true
             }
           }
         },
@@ -12944,44 +8611,18 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "2.1.1"
-          }
+          "dev": true
         },
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz"
-              }
-            }
-          }
-        },
-        "is-odd": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
-          "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
-          "dev": true,
-          "requires": {
-            "is-number": "4.0.0"
-          },
-          "dependencies": {
-            "is-number": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-              "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
               "dev": true
             }
           }
@@ -13005,55 +8646,22 @@
           "dev": true
         },
         "micromatch": {
-          "version": "3.1.9",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.9.tgz",
-          "integrity": "sha512-SlIz6sv5UPaAVVFRKodKjCg48EbNoIhgetzfK/Cy0v5U52Z6zB136M8tp0UC9jM53LYbmIRihJszvvqpKkfm9g==",
-          "dev": true,
-          "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "braces": "2.3.1",
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "extglob": "2.0.4",
-            "fragment-cache": "0.2.1",
-            "kind-of": "6.0.2",
-            "nanomatch": "1.2.9",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.0",
-            "snapdragon": "0.8.1",
-            "to-regex": "3.0.1"
-          }
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true
         },
-        "nanomatch": {
-          "version": "1.2.9",
-          "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
-          "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
-          "dev": true,
-          "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "fragment-cache": "0.2.1",
-            "is-odd": "2.0.0",
-            "is-windows": "1.0.2",
-            "kind-of": "6.0.2",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.0",
-            "snapdragon": "0.8.1",
-            "to-regex": "3.0.1"
-          }
+        "resolve": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+          "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+          "dev": true
         },
         "resolve-dir": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
           "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
-          "dev": true,
-          "requires": {
-            "expand-tilde": "2.0.2",
-            "global-modules": "1.0.0"
-          }
+          "dev": true
         }
       }
     },
@@ -13062,28 +8670,18 @@
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
-      "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
-      },
       "dependencies": {
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz"
-              }
+              "dev": true
             }
           }
         },
@@ -13091,10 +8689,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz"
-          }
+          "dev": true
         }
       }
     },
@@ -13109,68 +8704,52 @@
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
       "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
       "dev": true,
-      "requires": {
-        "bytes": "3.0.0",
-        "http-errors": "1.6.2",
-        "iconv-lite": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-        "unpipe": "1.0.0"
+      "dependencies": {
+        "depd": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
+          "dev": true
+        },
+        "http-errors": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+          "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+          "dev": true
+        },
+        "setprototypeof": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+          "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+          "dev": true
+        }
       }
     },
     "read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-      "requires": {
-        "load-json-file": "1.1.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "1.1.0"
-      }
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg="
     },
     "read-pkg-up": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
-      }
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI="
     },
     "readable-stream": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-      "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
-      }
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+      "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw=="
     },
     "readdirp": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.3.3",
-        "set-immediate-shim": "1.0.1"
-      }
+      "dev": true
     },
     "recast": {
       "version": "0.10.33",
       "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
       "integrity": "sha1-lCgI96oBbx+nFCxGHX5XBKqo1pc=",
-      "requires": {
-        "ast-types": "0.8.12",
-        "esprima-fb": "15001.1001.0-dev-harmony-fb",
-        "private": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
-      },
       "dependencies": {
         "ast-types": {
           "version": "0.8.12",
@@ -13182,20 +8761,13 @@
     "redent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-      "requires": {
-        "indent-string": "2.1.0",
-        "strip-indent": "1.0.1"
-      }
+      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94="
     },
     "redeyed": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-1.0.1.tgz",
       "integrity": "sha1-6WwZO0DAgWsArshCaY5hGF5VSYo=",
       "dev": true,
-      "requires": {
-        "esprima": "3.0.0"
-      },
       "dependencies": {
         "esprima": {
           "version": "3.0.0",
@@ -13206,74 +8778,47 @@
       }
     },
     "regenerate": {
-      "version": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
       "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
     },
     "regenerator": {
       "version": "0.8.40",
       "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
-      "integrity": "sha1-oORXxY69uuV1yfjNdRJ+k3VkNdg=",
-      "requires": {
-        "commoner": "0.10.8",
-        "defs": "1.1.1",
-        "esprima-fb": "15001.1001.0-dev-harmony-fb",
-        "private": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-        "recast": "0.10.33",
-        "through": "2.3.8"
-      }
+      "integrity": "sha1-oORXxY69uuV1yfjNdRJ+k3VkNdg="
     },
     "regenerator-runtime": {
-      "version": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
       "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "regenerator-transform": {
-      "version": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
-      "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
-      "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-        "private": "https://registry.npmjs.org/private/-/private-0.1.8.tgz"
-      }
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
+      "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q=="
     },
     "regex-cache": {
-      "version": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-      "dev": true,
-      "requires": {
-        "is-equal-shallow": "0.1.3"
-      }
+      "dev": true
     },
     "regex-not": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.0.tgz",
-      "integrity": "sha1-Qvg+OXcWIt+CawKvF2Ul1qXxV/k=",
-      "dev": true,
-      "requires": {
-        "extend-shallow": "2.0.1"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "0.1.1"
-          }
-        }
-      }
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "dev": true
+    },
+    "regexpp": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+      "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+      "dev": true
     },
     "regexpu": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
       "integrity": "sha1-5TTcmRqeWEYFDJjebX3UpVyeoW0=",
-      "requires": {
-        "esprima": "2.7.3",
-        "recast": "0.10.33",
-        "regenerate": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
-      },
       "dependencies": {
         "esprima": {
           "version": "2.7.3",
@@ -13285,12 +8830,7 @@
     "regexpu-core": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-      "requires": {
-        "regenerate": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
-      }
+      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA="
     },
     "regjsgen": {
       "version": "0.2.0",
@@ -13300,14 +8840,12 @@
     "regjsparser": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-      "requires": {
-        "jsesc": "0.5.0"
-      }
+      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw="
     },
     "remove-trailing-separator": {
-      "version": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
     },
     "repeat-element": {
@@ -13324,36 +8862,12 @@
     "repeating": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "requires": {
-        "is-finite": "1.0.2"
-      }
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo="
     },
     "request": {
-      "version": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-      "integrity": "sha512-e7MIJshe1eZAmRqg4ryaO0N9G0fs+/gpDe5FlbnIFy6zZznRSwdRFrLp63if0Yt43vrI5wowOqHv1qJdVocdOQ==",
-      "requires": {
-        "aws-sign2": "0.6.0",
-        "aws4": "1.6.0",
-        "caseless": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-        "combined-stream": "1.0.5",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.1.4",
-        "har-validator": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-        "hawk": "3.1.3",
-        "http-signature": "1.1.1",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-        "oauth-sign": "0.8.2",
-        "qs": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-        "stringstream": "0.0.5",
-        "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-        "tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-        "uuid": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz"
-      }
+      "version": "2.79.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+      "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4="
     },
     "require-directory": {
       "version": "2.1.1",
@@ -13369,11 +8883,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true,
-      "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
-      }
+      "dev": true
     },
     "requireindex": {
       "version": "1.1.0",
@@ -13388,21 +8898,15 @@
       "dev": true
     },
     "resolve": {
-      "version": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
-      "requires": {
-        "path-parse": "1.0.5"
-      }
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.6.0.tgz",
+      "integrity": "sha512-mw7JQNu5ExIkcw4LPih0owX/TZXjD/ZUF/ZQ/pDnkw3ZKhDcZZw5klmBlj6gVMwjQ3Pz5Jgu7F3d0jcDVuEWdw=="
     },
     "resolve-dir": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
       "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
-      "dev": true,
-      "requires": {
-        "expand-tilde": "1.2.2",
-        "global-modules": "0.2.3"
-      }
+      "dev": true
     },
     "resolve-from": {
       "version": "1.0.1",
@@ -13417,28 +8921,26 @@
       "dev": true
     },
     "restore-cursor": {
-      "version": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-      "integrity": "sha512-reSjH4HuiFlxlaBaFCiS6O76ZGG2ygKoSlCsipKdaZuKSPx/+bt9mULkn4l0asVzbEfQQmXRg6Wp6gv6m0wElw==",
-      "dev": true,
-      "requires": {
-        "exit-hook": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-        "onetime": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
-      }
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "dev": true
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
     },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "requires": {
-        "align-text": "0.1.4"
-      }
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8="
     },
     "rimraf": {
-      "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-      "requires": {
-        "glob": "7.1.2"
-      }
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w=="
     },
     "rsvp": {
       "version": "3.6.2",
@@ -13449,29 +8951,25 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-      "dev": true,
-      "requires": {
-        "is-promise": "2.1.0"
-      }
+      "dev": true
     },
     "rx": {
-      "version": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-      "integrity": "sha512-CiaiuN6gapkdl+cZUr67W6I8jquN4lkak3vtIsIWCl4XIPP8ffsoyN6/+PuGXnQy8Cu8W2y9Xxh31Rq4M6wUug==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
+      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
       "dev": true
     },
     "rx-lite": {
-      "version": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-      "integrity": "sha512-Cun9QucwK6MIrp3mry/Y7hqD1oFqTYLQ4pGxaHTjIdaFDWRGGLikqp6u8LcWJnzpoALg9hap+JGk8sFIUuEGNA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
       "dev": true
     },
     "rx-lite-aggregates": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-      "dev": true,
-      "requires": {
-        "rx-lite": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz"
-      }
+      "dev": true
     },
     "safe-buffer": {
       "version": "5.1.1",
@@ -13484,25 +8982,34 @@
       "integrity": "sha1-PnZyPjjf3aE8mx0poeB//uSzC1c=",
       "dev": true
     },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true
+    },
     "sane": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/sane/-/sane-1.7.0.tgz",
       "integrity": "sha1-s1ebzLRclM8gNVzIESSZDf00bjA=",
       "dev": true,
-      "requires": {
-        "anymatch": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-        "exec-sh": "0.2.1",
-        "fb-watchman": "2.0.0",
-        "minimatch": "3.0.4",
-        "minimist": "1.2.0",
-        "walker": "1.0.7",
-        "watch": "0.10.0"
-      },
       "dependencies": {
+        "anymatch": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+          "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+          "dev": true
+        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "watch": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/watch/-/watch-0.10.0.tgz",
+          "integrity": "sha1-d3mLLaD5kQ1ZXxrOWwwiWFIfIdw=",
           "dev": true
         }
       }
@@ -13511,12 +9018,6 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
       "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
-      "requires": {
-        "glob": "7.1.2",
-        "lodash": "4.17.4",
-        "scss-tokenizer": "0.2.3",
-        "yargs": "7.1.0"
-      },
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
@@ -13526,32 +9027,12 @@
         "cliui": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
-          }
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0="
         },
         "yargs": {
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
-          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
-          "requires": {
-            "camelcase": "3.0.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "5.0.0"
-          }
+          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg="
         }
       }
     },
@@ -13565,78 +9046,35 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
-      "requires": {
-        "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.2.tgz",
-        "source-map": "0.4.4"
-      },
       "dependencies": {
         "source-map": {
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "requires": {
-            "amdefine": "1.0.1"
-          }
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s="
         }
       }
     },
     "semver": {
-      "version": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
       "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
     },
     "send": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
-      "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
-      "dev": true,
-      "requires": {
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-        "depd": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-        "destroy": "1.0.4",
-        "encodeurl": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "1.6.2",
-        "mime": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-        "ms": "2.0.0",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.0",
-        "statuses": "1.3.1"
-      },
-      "dependencies": {
-        "mime": {
-          "version": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
-          "dev": true
-        }
-      }
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+      "dev": true
     },
     "serve-static": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
-      "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
-      "dev": true,
-      "requires": {
-        "encodeurl": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.2",
-        "send": "0.16.1"
-      }
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+      "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+      "dev": true
     },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-    },
-    "set-getter": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
-      "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
-      "dev": true,
-      "requires": {
-        "to-object-path": "0.3.0"
-      }
     },
     "set-immediate-shim": {
       "version": "1.0.1",
@@ -13649,21 +9087,12 @@
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "dev": true,
-      "requires": {
-        "extend-shallow": "2.0.1",
-        "is-extendable": "0.1.1",
-        "is-plain-object": "2.0.4",
-        "split-string": "3.1.0"
-      },
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "0.1.1"
-          }
+          "dev": true
         }
       }
     },
@@ -13677,20 +9106,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true,
-      "requires": {
-        "shebang-regex": "1.0.0"
-      }
+      "dev": true
     },
     "shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
-    },
-    "shelljs": {
-      "version": "https://registry.npmjs.org/shelljs/-/shelljs-0.2.6.tgz",
-      "integrity": "sha512-LQiM15qPbSyzHDFfI4v7EVhjBXG5PUAKWVBnVMBXwdlQSHZtzKYeKGzDHBIqpenPrCsPWqBSOF5o7oSvSfX+CA==",
-      "dev": true
     },
     "shellwords": {
       "version": "0.1.1",
@@ -13707,10 +9128,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/silent-error/-/silent-error-1.1.0.tgz",
       "integrity": "sha1-IglwbxyFCp8dENDYQJGLRvJuG8k=",
-      "dev": true,
-      "requires": {
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
-      }
+      "dev": true
     },
     "simple-fmt": {
       "version": "0.1.0",
@@ -13727,57 +9145,49 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
     },
-    "snapdragon": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.1.tgz",
-      "integrity": "sha1-4StUh/re0+PeoKyR6UAL91tAE3A=",
+    "slice-ansi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
-      "requires": {
-        "base": "0.11.2",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "map-cache": "0.2.2",
-        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-        "source-map-resolve": "0.5.1",
-        "use": "2.0.2"
-      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        }
+      }
+    },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "dev": true,
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true,
-          "requires": {
-            "is-descriptor": "0.1.6"
-          }
+          "dev": true
         },
         "extend-shallow": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "0.1.1"
-          }
+          "dev": true
         },
         "is-accessor-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz"
-              }
+              "dev": true
             }
           }
         },
@@ -13786,18 +9196,12 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz"
-              }
+              "dev": true
             }
           }
         },
@@ -13805,12 +9209,7 @@
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
-          }
+          "dev": true
         },
         "kind-of": {
           "version": "5.1.0",
@@ -13825,20 +9224,12 @@
       "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
-      "requires": {
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "snapdragon-util": "3.0.1"
-      },
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-          "dev": true,
-          "requires": {
-            "is-descriptor": "1.0.2"
-          }
+          "dev": true
         },
         "isobject": {
           "version": "3.0.1",
@@ -13852,42 +9243,24 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
-      "dev": true,
-      "requires": {
-        "kind-of": "3.2.2"
-      }
+      "dev": true
     },
     "sntp": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "requires": {
-        "hoek": "2.16.3"
-      }
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg="
     },
     "socket.io": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.6.0.tgz",
       "integrity": "sha1-PkDZMmN+a9kjmBslyvfFPoO24uE=",
       "dev": true,
-      "requires": {
-        "debug": "2.3.3",
-        "engine.io": "1.8.0",
-        "has-binary": "0.1.7",
-        "object-assign": "4.1.0",
-        "socket.io-adapter": "0.5.0",
-        "socket.io-client": "1.6.0",
-        "socket.io-parser": "2.3.1"
-      },
       "dependencies": {
         "debug": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.2"
-          }
+          "dev": true
         },
         "ms": {
           "version": "0.7.2",
@@ -13908,19 +9281,12 @@
       "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.5.0.tgz",
       "integrity": "sha1-y21LuL7IHhB4uZZ3+c7QBGBmu4s=",
       "dev": true,
-      "requires": {
-        "debug": "2.3.3",
-        "socket.io-parser": "2.3.1"
-      },
       "dependencies": {
         "debug": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.2"
-          }
+          "dev": true
         },
         "ms": {
           "version": "0.7.2",
@@ -13935,34 +9301,12 @@
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.6.0.tgz",
       "integrity": "sha1-W2aPT3cTBN/u0XkGRwg4b6ZxeFM=",
       "dev": true,
-      "requires": {
-        "backo2": "1.0.2",
-        "component-bind": "1.0.0",
-        "component-emitter": "1.2.1",
-        "debug": "2.3.3",
-        "engine.io-client": "1.8.0",
-        "has-binary": "0.1.7",
-        "indexof": "0.0.1",
-        "object-component": "0.0.3",
-        "parseuri": "0.0.5",
-        "socket.io-parser": "2.3.1",
-        "to-array": "0.1.4"
-      },
       "dependencies": {
-        "component-emitter": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-          "dev": true
-        },
         "debug": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.2"
-          }
+          "dev": true
         },
         "ms": {
           "version": "0.7.2",
@@ -13977,21 +9321,18 @@
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
       "integrity": "sha1-3VMgJRA85Clpcya+/WQAX8/ltKA=",
       "dev": true,
-      "requires": {
-        "component-emitter": "1.1.2",
-        "debug": "2.2.0",
-        "isarray": "0.0.1",
-        "json3": "3.3.2"
-      },
       "dependencies": {
+        "component-emitter": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
+          "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM=",
+          "dev": true
+        },
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
+          "dev": true
         },
         "isarray": {
           "version": "0.0.1",
@@ -14014,30 +9355,21 @@
       "dev": true
     },
     "sort-package-json": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-1.7.1.tgz",
-      "integrity": "sha1-8uX7/+hCDMG7BEhfRQnwXnO0wPI=",
-      "dev": true,
-      "requires": {
-        "sort-object-keys": "1.1.2"
-      }
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-1.11.0.tgz",
+      "integrity": "sha1-t7Wevfrz+HGewLwgViZOk3hoy/s=",
+      "dev": true
     },
     "source-map": {
-      "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "source-map-resolve": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
       "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
       "dev": true,
-      "requires": {
-        "atob": "2.0.3",
-        "decode-uri-component": "0.2.0",
-        "resolve-url": "0.2.1",
-        "source-map-url": "0.4.0",
-        "urix": "0.1.0"
-      },
       "dependencies": {
         "source-map-url": {
           "version": "0.4.0",
@@ -14048,11 +9380,9 @@
       }
     },
     "source-map-support": {
-      "version": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-      "requires": {
-        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
-      }
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA=="
     },
     "source-map-url": {
       "version": "0.3.0",
@@ -14061,15 +9391,10 @@
       "dev": true
     },
     "sourcemap-validator": {
-      "version": "https://registry.npmjs.org/sourcemap-validator/-/sourcemap-validator-1.0.6.tgz",
-      "integrity": "sha512-VkFKgW3Y09UFtVQqTPliuQaP/zXSUaQv5A2fZgnfeAooWH2EX8CFGAFHt5uLq3/uSsfXxyuJu972ECKyaOHC8Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/sourcemap-validator/-/sourcemap-validator-1.1.0.tgz",
+      "integrity": "sha512-Hmdu39KL+EoAAZ69OTk7RXXJdPRRizJvOZOWhCW9jLGfEQflCNPTlSoCXFPdKWFwwf0uzLcGR/fc7EP/PT8vRQ==",
       "dev": true,
-      "requires": {
-        "jsesc": "0.3.0",
-        "lodash.foreach": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-2.3.0.tgz",
-        "lodash.template": "2.3.0",
-        "source-map": "0.1.43"
-      },
       "dependencies": {
         "jsesc": {
           "version": "0.3.0",
@@ -14077,29 +9402,23 @@
           "integrity": "sha1-G/XuY7RTn+LibQwemcJAuXpFeXI=",
           "dev": true
         },
+        "lodash.defaults": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.3.0.tgz",
+          "integrity": "sha1-qDKwAfE487uXIcKBmip8xa4h7SU=",
+          "dev": true
+        },
         "lodash.template": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.3.0.tgz",
           "integrity": "sha1-Tj4pxDO0z+pnXsg15vEjkcYf0is=",
-          "dev": true,
-          "requires": {
-            "lodash._escapestringchar": "2.3.0",
-            "lodash._reinterpolate": "2.3.0",
-            "lodash.defaults": "2.3.0",
-            "lodash.escape": "2.3.0",
-            "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.3.0.tgz",
-            "lodash.templatesettings": "2.3.0",
-            "lodash.values": "2.3.0"
-          }
+          "dev": true
         },
         "source-map": {
           "version": "0.1.43",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "dev": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
+          "dev": true
         }
       }
     },
@@ -14110,40 +9429,36 @@
       "dev": true
     },
     "spawn-sync": {
-      "version": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
-      "integrity": "sha512-9DWBgrgYZzNghseho0JOuh+5fg9u6QWhAWa51QC7+U5rCheZ/j1DrEZnyE0RBBRqZ9uEXGPgSSM0nky6burpVw==",
-      "dev": true,
-      "requires": {
-        "concat-stream": "1.6.0",
-        "os-shim": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz"
-      }
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
+      "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
+      "dev": true
     },
     "spdx-correct": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-      "requires": {
-        "spdx-license-ids": "1.2.2"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+      "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g=="
+    },
+    "spdx-exceptions": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
     },
     "spdx-expression-parse": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg=="
     },
     "spdx-license-ids": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
     },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
-      "dev": true,
-      "requires": {
-        "extend-shallow": "3.0.2"
-      }
+      "dev": true
     },
     "sprintf-js": {
       "version": "1.1.1",
@@ -14157,19 +9472,9 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-      "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
-      },
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
+      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -14188,37 +9493,24 @@
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
-      "requires": {
-        "define-property": "0.2.5",
-        "object-copy": "0.1.0"
-      },
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true,
-          "requires": {
-            "is-descriptor": "0.1.6"
-          }
+          "dev": true
         },
         "is-accessor-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz"
-              }
+              "dev": true
             }
           }
         },
@@ -14227,18 +9519,12 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz"
-              }
+              "dev": true
             }
           }
         },
@@ -14246,12 +9532,7 @@
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
-          }
+          "dev": true
         },
         "kind-of": {
           "version": "5.1.0",
@@ -14262,18 +9543,20 @@
       }
     },
     "statuses": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
       "dev": true
     },
     "stdout-stream": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz",
-      "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
-      "requires": {
-        "readable-stream": "2.3.3"
-      }
+      "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s="
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ=="
     },
     "string-template": {
       "version": "0.2.1",
@@ -14284,20 +9567,7 @@
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M="
     },
     "stringmap": {
       "version": "0.2.2",
@@ -14317,14 +9587,12 @@
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "requires": {
-        "ansi-regex": "2.1.1"
-      }
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
     },
     "strip-bom": {
-      "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
     },
     "strip-eof": {
       "version": "1.0.0",
@@ -14335,10 +9603,7 @@
     "strip-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-      "requires": {
-        "get-stdin": "4.0.1"
-      }
+      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI="
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -14356,10 +9621,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.3.tgz",
       "integrity": "sha1-HGYfZnBX9jvLeHWqFDi8FiUlFW4=",
-      "dev": true,
-      "requires": {
-        "chalk": "1.1.3"
-      }
+      "dev": true
     },
     "supports-color": {
       "version": "2.0.0",
@@ -14371,16 +9633,13 @@
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.6.6.tgz",
       "integrity": "sha1-s0CIkDbyD5tEdUMHfQ9Vc+0ETAg=",
       "dev": true,
-      "requires": {
-        "coa": "1.0.4",
-        "colors": "1.1.2",
-        "csso": "2.0.0",
-        "js-yaml": "3.6.1",
-        "mkdirp": "0.5.1",
-        "sax": "1.2.4",
-        "whet.extend": "0.9.9"
-      },
       "dependencies": {
+        "colors": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+          "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+          "dev": true
+        },
         "esprima": {
           "version": "2.7.3",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
@@ -14391,49 +9650,81 @@
           "version": "3.6.1",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
           "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
-          "dev": true,
-          "requires": {
-            "argparse": "1.0.9",
-            "esprima": "2.7.3"
-          }
+          "dev": true
         }
       }
     },
     "symlink-or-copy": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.1.8.tgz",
-      "integrity": "sha1-yr5h4AEMHAI8Fzsl7lEIs39LSqM="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.2.0.tgz",
+      "integrity": "sha512-W31+GLiBmU/ZR02Ii0mVZICuNEN9daZ63xZMPDsYgPgNjMtg+atqLEGI7PPI936jYSQZxoLb/63xos8Adrx4Eg=="
+    },
+    "table": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "dev": true
+        }
+      }
     },
     "tap-parser": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-5.4.0.tgz",
       "integrity": "sha512-BIsIaGqv7uTQgTW1KLTMNPSEQf4zDDPgYOBRdgOfuB+JFOLRBfEu6cLa/KvMvmqggu1FKXDfitjLwsq4827RvA==",
-      "dev": true,
-      "requires": {
-        "events-to-array": "1.1.2",
-        "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-        "readable-stream": "2.3.3"
-      }
+      "dev": true
     },
     "tar": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-      "requires": {
-        "block-stream": "0.0.9",
-        "fstream": "1.0.11",
-        "inherits": "2.0.3"
-      }
+      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE="
     },
     "temp": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
       "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
       "dev": true,
-      "requires": {
-        "os-tmpdir": "1.0.2",
-        "rimraf": "2.2.8"
-      },
       "dependencies": {
         "rimraf": {
           "version": "2.2.8",
@@ -14448,34 +9739,6 @@
       "resolved": "https://registry.npmjs.org/testem/-/testem-1.18.4.tgz",
       "integrity": "sha1-5F/tkivsL1SmFsQ/EZIlmKyX60E=",
       "dev": true,
-      "requires": {
-        "backbone": "1.3.3",
-        "bluebird": "3.5.1",
-        "charm": "1.0.2",
-        "commander": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-        "consolidate": "0.14.5",
-        "cross-spawn": "5.1.0",
-        "express": "4.16.2",
-        "fireworm": "0.7.1",
-        "glob": "7.1.2",
-        "http-proxy": "1.16.2",
-        "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-        "lodash.assignin": "4.2.0",
-        "lodash.clonedeep": "4.5.0",
-        "lodash.find": "4.6.0",
-        "lodash.uniqby": "4.7.0",
-        "mkdirp": "0.5.1",
-        "mustache": "2.3.0",
-        "node-notifier": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
-        "npmlog": "4.1.2",
-        "printf": "0.2.5",
-        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-        "socket.io": "1.6.0",
-        "spawn-args": "0.2.0",
-        "styled_string": "0.0.1",
-        "tap-parser": "5.4.0",
-        "xmldom": "0.1.27"
-      },
       "dependencies": {
         "bluebird": {
           "version": "3.5.1",
@@ -14487,12 +9750,7 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "4.1.1",
-            "shebang-command": "1.2.0",
-            "which": "https://registry.npmjs.org/which/-/which-1.3.0.tgz"
-          }
+          "dev": true
         }
       }
     },
@@ -14503,9 +9761,9 @@
       "dev": true
     },
     "textextensions": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.1.0.tgz",
-      "integrity": "sha1-G+DcKg3CRNRL6KCa9qha+5PE28M="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.2.0.tgz",
+      "integrity": "sha512-j5EMxnryTvKxwH2Cq+Pb43tsf6sdEgw6Pdwxk83mPaq0ToeFJt6WE4J3s5BqY7vmjlLgkgXvhtXUxo80FyBhCA=="
     },
     "through": {
       "version": "2.3.8",
@@ -14513,18 +9771,17 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "tiny-lr": {
-      "version": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-1.1.0.tgz",
-      "integrity": "sha512-f4X68a6KHcCx/XJcZUKAa92APjY9EHxuGOzRFmPRjf+fOp1E7fi4dGJaHMxvRBxwZrHrIvn/AwkFaDS7O1WZDQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-1.1.1.tgz",
+      "integrity": "sha512-44yhA3tsaRoMOjQQ+5v5mVdqef+kH6Qze9jTpqtVufgYjYt08zyZAwNwwVBj3i1rJMnR52IxOW0LK0vBzgAkuA==",
       "dev": true,
-      "requires": {
-        "body": "5.1.0",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-        "faye-websocket": "0.10.0",
-        "livereload-js": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.3.0.tgz",
-        "object-assign": "4.1.1",
-        "qs": "6.5.1"
-      },
       "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true
+        },
         "qs": {
           "version": "6.5.1",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
@@ -14536,10 +9793,7 @@
     "tmp": {
       "version": "0.0.28",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
-      "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
-      "requires": {
-        "os-tmpdir": "1.0.2"
-      }
+      "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA="
     },
     "tmpl": {
       "version": "1.0.4",
@@ -14562,147 +9816,42 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
-      "dev": true,
-      "requires": {
-        "kind-of": "3.2.2"
-      }
+      "dev": true
     },
     "to-regex": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.1.tgz",
-      "integrity": "sha1-FTWL7kosg712N3uh3ASdDxiDeq4=",
-      "dev": true,
-      "requires": {
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "regex-not": "1.0.0"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true,
-          "requires": {
-            "is-descriptor": "0.1.6"
-          }
-        },
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "0.1.1"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz"
-              }
-            }
-          }
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz"
-              }
-            }
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
-          }
-        },
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-          "dev": true
-        }
-      }
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true
     },
     "to-regex-range": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
-      "requires": {
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1"
-      },
       "dependencies": {
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          }
+          "dev": true
         }
       }
     },
     "tough-cookie": {
-      "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-      "integrity": "sha512-WR9pjSY3qO0z3yC6g33CRcVt2Wbevh0gP1XiSFql0/xRioi9qbDs3C+g4Nv2N8jmv/BloIi/SYoy/mfw5vus2A==",
-      "requires": {
-        "punycode": "1.4.1"
-      }
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA=="
     },
     "tree-sync": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-sync/-/tree-sync-1.2.2.tgz",
       "integrity": "sha1-LPdrhYn1n/7bWNtaOsfLAT0BWLc=",
-      "requires": {
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-        "fs-tree-diff": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.7.tgz",
-        "mkdirp": "0.5.1",
-        "quick-temp": "0.1.8",
-        "walk-sync": "0.2.7"
-      },
       "dependencies": {
         "walk-sync": {
           "version": "0.2.7",
           "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.7.tgz",
-          "integrity": "sha1-tJvk7mhnZXrrc2l4tWop0Q+jmWk=",
-          "requires": {
-            "ensure-posix-path": "1.0.2",
-            "matcher-collection": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.5.tgz"
-          }
+          "integrity": "sha1-tJvk7mhnZXrrc2l4tWop0Q+jmWk="
         }
       }
     },
@@ -14717,23 +9866,14 @@
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "true-case-path": {
-      "version": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.2.tgz",
-      "integrity": "sha512-V+GMXPNi/DBC48X1/QOQkQjbMxKfcT4De7uNqqO2SKede+dtLNtabT8Ckv6myI9T+oT+KOECo97mRuosmyyclw==",
-      "requires": {
-        "glob": "6.0.4"
-      },
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.2.tgz",
+      "integrity": "sha1-fskRMJJHZsf1c74wIMNPj9/QDWI=",
       "dependencies": {
         "glob": {
           "version": "6.0.4",
           "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-          "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI="
         }
       }
     },
@@ -14748,8 +9888,9 @@
       "integrity": "sha1-gUXkynyv9ArN48z5Rui4u3W0Fys="
     },
     "tunnel-agent": {
-      "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-      "integrity": "sha512-e0IoVDWx8SDHc/hwFTqJDQ7CCDTEeGhmcT9jkWJjoGQSpgBz20nAMr80E3Tpk7PatJ1b37DQDgJR3CNSzcMOZQ=="
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
     },
     "tweetnacl": {
       "version": "0.14.5",
@@ -14761,20 +9902,13 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "1.1.2"
-      }
+      "dev": true
     },
     "type-is": {
-      "version": "1.6.15",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
-      "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
-      "dev": true,
-      "requires": {
-        "media-typer": "0.3.0",
-        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz"
-      }
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+      "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+      "dev": true
     },
     "typedarray": {
       "version": "0.0.6",
@@ -14783,9 +9917,9 @@
       "dev": true
     },
     "uc.micro": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.3.tgz",
-      "integrity": "sha1-ftUNXg+an7ClczeSWfKndFjVAZI=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.5.tgz",
+      "integrity": "sha512-JoLI4g5zv5qNyT09f4YAvEZIIV1oOjqnewYg5D38dkQljIzpPT296dbIGvKro3digYI1bkb7W6EP1y4uDlmzLg==",
       "dev": true
     },
     "uglify-js": {
@@ -14794,11 +9928,6 @@
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "dev": true,
       "optional": true,
-      "requires": {
-        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
-      },
       "dependencies": {
         "window-size": {
           "version": "0.1.0",
@@ -14812,13 +9941,7 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
-            "window-size": "0.1.0"
-          }
+          "optional": true
         }
       }
     },
@@ -14844,44 +9967,25 @@
     "underscore.string": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
-      "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
-      "requires": {
-        "sprintf-js": "1.1.1",
-        "util-deprecate": "1.0.2"
-      }
+      "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s="
     },
     "union-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "dev": true,
-      "requires": {
-        "arr-union": "3.1.0",
-        "get-value": "2.0.6",
-        "is-extendable": "0.1.1",
-        "set-value": "0.4.3"
-      },
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "0.1.1"
-          }
+          "dev": true
         },
         "set-value": {
           "version": "0.4.3",
           "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "to-object-path": "0.3.0"
-          }
+          "dev": true
         }
       }
     },
@@ -14889,10 +9993,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
-      "dev": true,
-      "requires": {
-        "crypto-random-string": "1.0.0"
-      }
+      "dev": true
     },
     "universalify": {
       "version": "0.1.1",
@@ -14911,30 +10012,18 @@
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
-      "requires": {
-        "has-value": "0.3.1",
-        "isobject": "3.0.1"
-      },
       "dependencies": {
         "has-value": {
           "version": "0.3.1",
           "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
-          "requires": {
-            "get-value": "2.0.6",
-            "has-values": "0.1.4",
-            "isobject": "2.1.0"
-          },
           "dependencies": {
             "isobject": {
               "version": "2.1.0",
               "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
               "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-              "dev": true,
-              "requires": {
-                "isarray": "1.0.0"
-              }
+              "dev": true
             }
           }
         },
@@ -14956,10 +10045,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
       "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
-      "dev": true,
-      "requires": {
-        "os-homedir": "1.0.2"
-      }
+      "dev": true
     },
     "urix": {
       "version": "0.1.0",
@@ -14968,96 +10054,16 @@
       "dev": true
     },
     "use": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/use/-/use-2.0.2.tgz",
-      "integrity": "sha1-riig1y+TvyJCKhii43mZMRLeyOg=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
+      "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
       "dev": true,
-      "requires": {
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "lazy-cache": "2.0.2"
-      },
       "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true,
-          "requires": {
-            "is-descriptor": "0.1.6"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz"
-              }
-            }
-          }
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz"
-              }
-            }
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
-        },
         "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "dev": true,
-          "requires": {
-            "set-getter": "0.1.0"
-          }
         }
       }
     },
@@ -15067,22 +10073,16 @@
       "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
     },
     "user-info": {
-      "version": "https://registry.npmjs.org/user-info/-/user-info-1.0.0.tgz",
-      "integrity": "sha512-nfV4K41XIV6h7Ap2AAZjsbJbDKug1ThhZK38MNpX5GaXl5s710VFfwbGGuJh12hFmKJGe+7mT5lmWY+SNLlhaA==",
-      "dev": true,
-      "requires": {
-        "os-homedir": "1.0.2",
-        "passwd-user": "https://registry.npmjs.org/passwd-user/-/passwd-user-1.2.1.tgz",
-        "username": "https://registry.npmjs.org/username/-/username-1.0.1.tgz"
-      }
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/user-info/-/user-info-1.0.0.tgz",
+      "integrity": "sha1-gcgrftY+Z0wkdWZ2U0E7PHb94jk=",
+      "dev": true
     },
     "username": {
-      "version": "https://registry.npmjs.org/username/-/username-1.0.1.tgz",
-      "integrity": "sha512-gv4xIlKfkC+mcSHcN0jrsNJp5N6G7kz69gyBw26GVW3/p4OXG3v9ABlkmggbIFWtCkXuep/ifDO/bsAJkD7XBQ==",
-      "dev": true,
-      "requires": {
-        "meow": "3.7.0"
-      }
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/username/-/username-1.0.1.tgz",
+      "integrity": "sha1-4fcilePljgbwAsYyfOBol6mc1n8=",
+      "dev": true
     },
     "username-sync": {
       "version": "1.0.1",
@@ -15101,26 +10101,20 @@
       "dev": true
     },
     "uuid": {
-      "version": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
       "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
     },
     "validate-npm-package-license": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-      "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
-      }
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+      "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g=="
     },
     "validate-npm-package-name": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
       "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
-      "dev": true,
-      "requires": {
-        "builtins": "1.0.3"
-      }
+      "dev": true
     },
     "vary": {
       "version": "1.1.2",
@@ -15129,13 +10123,9 @@
       "dev": true
     },
     "verror": {
-      "version": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz"
-      },
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -15147,39 +10137,43 @@
     "walk-sync": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.2.tgz",
-      "integrity": "sha512-FMB5VqpLqOCcqrzA9okZFc0wq0Qbmdm396qJxvQZhDpyu0W95G9JCmp74tx7iyYnyOcBtUuKJsgIKAqjozvmmQ==",
-      "requires": {
-        "ensure-posix-path": "1.0.2",
-        "matcher-collection": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.5.tgz"
-      }
+      "integrity": "sha512-FMB5VqpLqOCcqrzA9okZFc0wq0Qbmdm396qJxvQZhDpyu0W95G9JCmp74tx7iyYnyOcBtUuKJsgIKAqjozvmmQ=="
     },
     "walker": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
-      "dev": true,
-      "requires": {
-        "makeerror": "1.0.11"
-      }
+      "dev": true
     },
     "watch": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/watch/-/watch-0.10.0.tgz",
-      "integrity": "sha1-d3mLLaD5kQ1ZXxrOWwwiWFIfIdw=",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
+      "integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
+      "dev": true,
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
       "dev": true
     },
     "websocket-driver": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
-      "dev": true,
-      "requires": {
-        "http-parser-js": "0.4.9",
-        "websocket-extensions": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz"
-      }
+      "dev": true
     },
     "websocket-extensions": {
-      "version": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
       "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
       "dev": true
     },
@@ -15190,11 +10184,9 @@
       "dev": true
     },
     "which": {
-      "version": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-      "requires": {
-        "isexe": "2.0.0"
-      }
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg=="
     },
     "which-module": {
       "version": "1.0.0",
@@ -15204,10 +10196,7 @@
     "wide-align": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-      "requires": {
-        "string-width": "1.0.2"
-      }
+      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w=="
     },
     "window-size": {
       "version": "0.1.4",
@@ -15220,20 +10209,14 @@
       "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
     },
     "workerpool": {
-      "version": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.0.tgz",
-      "integrity": "sha512-JP5DpviEV84zDmz13QnD4FfRjZBjnTOYY2O4pGgxtlqLh47WOzQFHm8o17TE5OSfcDoKC6vHSrN4yPju93DW0Q==",
-      "requires": {
-        "object-assign": "4.1.1"
-      }
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.0.tgz",
+      "integrity": "sha512-JP5DpviEV84zDmz13QnD4FfRjZBjnTOYY2O4pGgxtlqLh47WOzQFHm8o17TE5OSfcDoKC6vHSrN4yPju93DW0Q=="
     },
     "wrap-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-      "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
-      }
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU="
     },
     "wrappy": {
       "version": "1.0.2",
@@ -15244,31 +10227,19 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-      "dev": true,
-      "requires": {
-        "mkdirp": "0.5.1"
-      }
+      "dev": true
     },
     "write-file-atomic": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
       "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "imurmurhash": "0.1.4",
-        "signal-exit": "3.0.2"
-      }
+      "dev": true
     },
     "ws": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
       "integrity": "sha1-CC3bbGQehdS7RR8D1S8G6r2x8Bg=",
-      "dev": true,
-      "requires": {
-        "options": "0.0.6",
-        "ultron": "1.0.2"
-      }
+      "dev": true
     },
     "wtf-8": {
       "version": "1.0.0",
@@ -15314,46 +10285,24 @@
       "resolved": "https://registry.npmjs.org/yam/-/yam-0.0.22.tgz",
       "integrity": "sha1-OKdst5oZKE2SBu1JAx41mhNAvQY=",
       "dev": true,
-      "requires": {
-        "fs-extra": "0.30.0",
-        "lodash.merge": "4.6.0"
-      },
       "dependencies": {
         "fs-extra": {
           "version": "0.30.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
           "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.1",
-            "path-is-absolute": "1.0.1",
-            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz"
-          }
+          "dev": true
         }
       }
     },
     "yargs": {
       "version": "3.27.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
-      "integrity": "sha1-ISBUaTFuk5Ex1Z8toMbX+YIh6kA=",
-      "requires": {
-        "camelcase": "1.2.1",
-        "cliui": "2.1.0",
-        "decamelize": "1.2.0",
-        "os-locale": "1.4.0",
-        "window-size": "0.1.4",
-        "y18n": "3.2.1"
-      }
+      "integrity": "sha1-ISBUaTFuk5Ex1Z8toMbX+YIh6kA="
     },
     "yargs-parser": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
       "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
-      "requires": {
-        "camelcase": "3.0.0"
-      },
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-uniq",
-  "version": "0.3.0",
+  "version": "0.2.14",
   "description": "Ember add-on with a variety of components with uniplaces-uniq styles and default behaviours.",
   "keywords": [
     "ember-addon"
@@ -22,11 +22,11 @@
     "deploy-to-gh-pages": "ember github-pages:commit --message \"Deploy gh-pages from commit $(git rev-parse HEAD)\"; git push -u origin gh-pages"
   },
   "dependencies": {
-    "broccoli-funnel": "^1.0.7",
+    "broccoli-funnel": "^1.2.0",
     "ember-cli-babel": "6.6.0",
     "ember-cli-countries": "0.0.3",
     "ember-cli-htmlbars": "2.0.1",
-    "ember-cli-sass": "^6.1.3",
+    "ember-cli-sass": "^7.1.2",
     "ember-power-calendar": "^0.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
# What this does?
- This is inline with the #220, this is a better way of doing it
Now projects can have the "excludeAssets" in their `ember-cli-build` to choose which assets to exclude from build

# Example from a project using the flag

**before**
File sizes:
 - dist/assets/spa-search-9ba8142399b1e60bc63ea0980d74c72b.css: 65.71 KB (11.62 KB gzipped)
 - dist/assets/spa-search-d3741e01394b1f548a53279a2982494d.js: 4.89 MB (1.33 MB gzipped)
 - dist/assets/vendor-a4e7e9f519fe06273612b4377c4a7ed9.css: 118.53 KB (24.85 KB gzipped)
 - dist/assets/vendor-cb6c20ac701215fcb952201297bd9d88.js: 3.51 MB (733.84 KB gzipped)
 - dist/ember-fetch/fastboot-fetch-805e176077930c98aec5834ae48bd0f2.js: 283 B (199 B gzipped)
 - dist/sw.js: 5.29 KB (1.74 KB gzipped)

**after**

