### PR TITLE
[RFC][UN-12356] Improvements on uni-autocomplete selection when focusing out the component

### DIFF
--- a/addon/components/uni-autocomplete.js
+++ b/addon/components/uni-autocomplete.js
@@ -2,12 +2,11 @@ import { computed } from '@ember/object';
 import { isPresent, isBlank, isEmpty } from '@ember/utils';
 import Component from '@ember/component';
 import layout from '../templates/components/uni-autocomplete';
-import ClickOutside from '../mixins/click-outside';
 import KeyCodes from 'ember-cli-uniq/enums/key-codes-type';
 import { A } from '@ember/array';
 import { capitalize } from '@ember/string';
 
-export default Component.extend(ClickOutside, {
+export default Component.extend({
   classNames: ['uni-autocomplete'],
   layout,
   noResultsComponent: 'uni-autocomplete-no-results',
@@ -89,6 +88,13 @@ export default Component.extend(ClickOutside, {
     showOptions() {
       this.set('highlighted', 0);
       this.set('showOptions', true);
+    },
+
+    onFocusOut() {
+      let highlightedOption = this.get('autocompleteOption');
+      if (isPresent(highlightedOption)) {
+        this.selectOption(highlightedOption);
+      }
     }
   },
 
@@ -97,22 +103,6 @@ export default Component.extend(ClickOutside, {
 
     this.get('onSelected')(option);
     this.set('showOptions', false);
-  },
-
-  isComponentDestroyed() {
-    return this.get('isDestroyed') || this.get('isDestroying');
-  },
-
-  onOutsideClick() {
-    if (this.isComponentDestroyed() || !this.get('showOptions')) {
-      return;
-    }
-
-    let option = this.get('autocompleteOption');
-
-    return isEmpty(option)
-      ? this.set('showOptions', false)
-      : this.selectOption(option);
   },
 
   filterFunction(getSearchTextValues, option) {

--- a/addon/components/uni-autocomplete.js
+++ b/addon/components/uni-autocomplete.js
@@ -72,6 +72,8 @@ export default Component.extend({
     return optionText.replace(matchingLetters, value);
   }),
 
+  onFocusOut() {},
+
   actions: {
     onSelected(option) {
       this.selectOption(option);
@@ -90,11 +92,15 @@ export default Component.extend({
       this.set('showOptions', true);
     },
 
-    onFocusOut() {
+    selectHighlightedOption() {
       let highlightedOption = this.get('autocompleteOption');
       if (isPresent(highlightedOption)) {
         this.selectOption(highlightedOption);
       }
+    },
+
+    onFocusOut() {
+      this.get('onFocusOut')();
     }
   },
 

--- a/addon/templates/components/uni-autocomplete.hbs
+++ b/addon/templates/components/uni-autocomplete.hbs
@@ -5,6 +5,7 @@
   placeholder=(if placeholder placeholder placeholderText)
   autocomplete=autocomplete
   focus-in=(action "showOptions")
+  focus-out=(action "onFocusOut")
   class=(i 'uni-input uni-input--bordered ${errorClass}' errorClass=(if hasError 'uni-input--error'))
   key-down=(action "keyPress")}}
 

--- a/addon/templates/components/uni-autocomplete.hbs
+++ b/addon/templates/components/uni-autocomplete.hbs
@@ -5,7 +5,7 @@
   placeholder=(if placeholder placeholder placeholderText)
   autocomplete=autocomplete
   focus-in=(action "showOptions")
-  focus-out=(action "onFocusOut")
+  focus-out=(queue (action "selectHighlightedOption") (action "onFocusOut"))
   class=(i 'uni-input uni-input--bordered ${errorClass}' errorClass=(if hasError 'uni-input--error'))
   key-down=(action "keyPress")}}
 

--- a/tests/integration/components/uni-autocomplete-test.js
+++ b/tests/integration/components/uni-autocomplete-test.js
@@ -1,6 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { fillIn, keyEvent } from 'ember-native-dom-helpers';
+import { fillIn, keyEvent, triggerEvent, find } from 'ember-native-dom-helpers';
 import { A } from '@ember/array';
 
 moduleForComponent('uni-autocomplete', 'Integration | Component | uni autocomplete', {
@@ -70,4 +70,17 @@ test('it works with a custom filter function', async function(assert) {
 
   await fillIn('.uni-input', 'A');
   await keyEvent('.uni-input', 'keydown', letterAKeyCode);
+});
+
+test('It selects a highlighted option when focusing out', async function(assert) {
+  assert.expect(1);
+
+  this.setProperties({ searchTextValues: (option) => [option], options: ['ABC', 'A', 'B', 'C'] });
+
+  this.render(hbs`{{uni-autocomplete options=options searchTextValues=searchTextValues}}`);
+
+  await fillIn('input', 'ab');
+  await triggerEvent('input', 'blur');
+
+  assert.equal(find('input').value, 'Abc');
 });


### PR DESCRIPTION
https://uniplaces.atlassian.net/browse/UN-12356

## Context

Currently at checkout, we are having a flaky behaviour with the country field being automatically selected with the highlighted option on focusing out. Sometimes it works, sometimes not. 
The most likely cause, after testing the interactions,  is the multiple ```click outside``` events registrations we are doing with multiple components. 
Since we can achieve the same behaviour with ```focus-out``` input event,  I think it's better to use it and it fixes the problem too.