### PR TITLE
[RFC][UN-12855] Tooltips not opening on ios

### DIFF
--- a/addon/components/uni-tooltip.js
+++ b/addon/components/uni-tooltip.js
@@ -46,7 +46,7 @@ export default Component.extend(ClickOutsideMixin, {
       }
 
       this._showTooltip();
-      if (this.get('media.isMobile')) { 
+      if (this.get('media.isMobile')) {
         run.later(this, () => this._setTopPositionMobile(), 0);
       }
     }

--- a/addon/components/uni-tooltip.js
+++ b/addon/components/uni-tooltip.js
@@ -74,5 +74,5 @@ export default Component.extend(ClickOutsideMixin, {
 
   isComponentDestroyed() {
     return this.get('isDestroyed') || this.get('isDestroying');
-  },
+  }
 });

--- a/addon/components/uni-tooltip.js
+++ b/addon/components/uni-tooltip.js
@@ -38,15 +38,15 @@ export default Component.extend(ClickOutsideMixin, {
       if (this.get('isAlternative')) {
         return;
       }
-  
+
       if (this.get('isActive')) {
         this._hideTooltip();
-  
+
         return;
       }
-  
+
       this._showTooltip();
-      if (this.get('media.isMobile')) {
+      if (this.get('media.isMobile')) { 
         run.later(this, () => this._setTopPositionMobile(), 0);
       }
     }

--- a/addon/components/uni-tooltip.js
+++ b/addon/components/uni-tooltip.js
@@ -31,24 +31,24 @@ export default Component.extend(ClickOutsideMixin, {
     this._hideTooltip();
   },
 
-  click(ev) {
-    ev.stopPropagation();
+  actions: {
+    onTapOrClick() {
+      this.get('onClick')();
 
-    this.get('onClick')();
-
-    if (this.get('isAlternative')) {
-      return;
-    }
-
-    if (this.get('isActive')) {
-      this._hideTooltip();
-
-      return;
-    }
-
-    this._showTooltip();
-    if (this.get('media.isMobile')) {
-      run.later(this, () => this._setTopPositionMobile(), 0);
+      if (this.get('isAlternative')) {
+        return;
+      }
+  
+      if (this.get('isActive')) {
+        this._hideTooltip();
+  
+        return;
+      }
+  
+      this._showTooltip();
+      if (this.get('media.isMobile')) {
+        run.later(this, () => this._setTopPositionMobile(), 0);
+      }
     }
   },
 
@@ -74,5 +74,5 @@ export default Component.extend(ClickOutsideMixin, {
 
   isComponentDestroyed() {
     return this.get('isDestroyed') || this.get('isDestroying');
-  }
+  },
 });

--- a/addon/templates/components/uni-tooltip.hbs
+++ b/addon/templates/components/uni-tooltip.hbs
@@ -1,4 +1,4 @@
-<span class="uni-tooltip__icon">
+<span class="uni-tooltip__icon" {{action "onTapOrClick"}}>
     {{#if isInformation}}
         {{inline-svg "icons/information-icon"}}
     {{else if isQuestion}}

--- a/tests/integration/components/uni-tooltip-test.js
+++ b/tests/integration/components/uni-tooltip-test.js
@@ -1,20 +1,17 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { click, find } from 'ember-native-dom-helpers';
-import getOwner from 'ember-owner/get';
+import { setBreakpointForIntegrationTest } from '../../helpers/responsive';
 
 moduleForComponent('uni-tooltip', 'Integration | Component | uni tooltip', {
-  integration: true,
-  beforeEach() {
-    let mediaService = getOwner(this).lookup('service:media');
-    mediaService.set('isMobile', true);
-  }
+  integration: true
 });
 
 test('it renders', function(assert) {
   assert.expect(3);
 
-  this.render(hbs`{{uni-tooltip}}`);
+  setBreakpointForIntegrationTest(this, 'mobile');
+  this.render(hbs`{{uni-tooltip media=media}}`);
 
   assert.equal(this.$().text().trim(), '');
   assert.notOk(find('.uni-tooltip__text'));

--- a/tests/integration/components/uni-tooltip-test.js
+++ b/tests/integration/components/uni-tooltip-test.js
@@ -1,12 +1,25 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { click, find } from 'ember-native-dom-helpers';
+import getOwner from 'ember-owner/get';
 
 moduleForComponent('uni-tooltip', 'Integration | Component | uni tooltip', {
-  integration: true
+  integration: true,
+  beforeEach() {
+    let mediaService = getOwner(this).lookup('service:media');
+    mediaService.set('isMobile', true);
+  }
 });
 
 test('it renders', function(assert) {
+  assert.expect(3);
+
   this.render(hbs`{{uni-tooltip}}`);
 
   assert.equal(this.$().text().trim(), '');
+  assert.notOk(find('.uni-tooltip__text'));
+
+  click('.uni-tooltip__icon');
+
+  assert.ok(find('.uni-tooltip__text'));
 });


### PR DESCRIPTION
https://uniplaces.atlassian.net/browse/UN-12855

Tooltips are not opening on ios devices because the click event is not being triggered. I tried to only change the tooltip component to accommodate both `click` and `touchStart` events but this is breaking android, because both handlers are called. This was the cleanest way I found to fix it.