### PR TITLE
[RFC][NI] Add readOnly property to checked property on radio-button

### DIFF
--- a/addon/components/uni-radio-button.js
+++ b/addon/components/uni-radio-button.js
@@ -1,6 +1,6 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
-import { isPresent } from '@ember/utils';
+import { isPresent, isEqual } from '@ember/utils';
 import layout from '../templates/components/uni-radio-button';
 
 export default Component.extend({
@@ -16,9 +16,9 @@ export default Component.extend({
 
   hasChanged() {},
 
-  checked: computed('value', 'groupValue', function() {
-    return this.get('value') === this.get('groupValue');
-  }),
+  checked: computed('groupValue', 'value', function() {
+    return isEqual(this.get('groupValue'), this.get('value'));
+  }).readOnly(),
 
   change() {
     this.get('hasChanged')(this.get('value'));

--- a/tests/dummy/app/templates/components/demo-page.hbs
+++ b/tests/dummy/app/templates/components/demo-page.hbs
@@ -299,11 +299,12 @@
           This is a component used for radio button inputs.
         </p>
 
-        {{uni-radio-button checked=true label="Checked radio button"}}
-        {{uni-radio-button checked=false label="Unchecked radio button"}}
-        {{uni-radio-button label="Disabled radio button" isDisabled=true}}
-
+        {{uni-radio-button value="yes" groupValue="yes" label="Checked radio button"}}
+        {{uni-radio-button value="no" groupValue="yes" label="Unchecked radio button"}}
         {{code-snippet name="uni-radio-button-1.hbs"}}
+
+        {{uni-radio-button label="Disabled radio button" isDisabled=true}}
+        {{code-snippet name="uni-radio-button-2.hbs"}}
       </div>
     </div>
 

--- a/tests/dummy/app/templates/snippets/uni-radio-button-1.hbs
+++ b/tests/dummy/app/templates/snippets/uni-radio-button-1.hbs
@@ -1,3 +1,2 @@
-{{uni-radio-button checked=true label="Checked radio button"}}
-{{uni-radio-button checked=false label="Unchecked radio button"}}
-{{uni-radio-button label="Disabled radio button" isDisabled=true}}
+{{uni-radio-button value="yes" groupValue="yes" label="Checked radio button"}}
+{{uni-radio-button value="no"  groupValue="yes" label="Unchecked radio button"}}

--- a/tests/dummy/app/templates/snippets/uni-radio-button-2.hbs
+++ b/tests/dummy/app/templates/snippets/uni-radio-button-2.hbs
@@ -1,0 +1,1 @@
+{{uni-radio-button label="Disabled radio button" isDisabled=true}}

--- a/tests/integration/components/uni-radio-button-test.js
+++ b/tests/integration/components/uni-radio-button-test.js
@@ -1,40 +1,66 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-
-const DEFAULT_LABEL = 'Radio option';
+import { click } from 'ember-native-dom-helpers';
 
 moduleForComponent('uni-radio-button', 'Integration | Component | uni radio button', {
-  integration: true
+  integration: true,
+  beforeEach() {
+    this.set('label', 'This is a default label');
+  }
 });
 
-test('it renders', function(assert) {
+test('It renders', function(assert) {
+  assert.expect(4);
+
+  this.render(hbs`{{uni-radio-button label=label}}`);
+
+  assert.dom('.uni-radio-button').exists();
+  assert.dom('.uni-radio-button input').isNotDisabled();
+  assert.dom('label').exists();
+  assert.dom('label').hasText('This is a default label');
+});
+
+test('It renders as disabled', function(assert) {
+  assert.expect(2);
+
+  this.set('isDisabled', true);
+
+  this.render(hbs`{{uni-radio-button label=label isDisabled=isDisabled}}`);
+
+  assert.dom('.uni-radio-button--disabled').exists();
+  assert.dom('.uni-radio-button input').isDisabled();
+});
+
+test('It renders as checked when the groupValue is the same as the value', function(assert) {
   assert.expect(1);
 
-  this.render(hbs`{{uni-radio-button}}`);
+  this.set('groupValue', 'javascript');
+  this.set('value', 'javascript');
 
-  assert.equal(this.$().text().trim(), '');
+  this.render(hbs`{{uni-radio-button label=label value=value groupValue=groupValue}}`);
+
+  assert.dom('.uni-radio-button input').isChecked();
 });
 
-test('it renders checked', function(assert) {
-  assert.expect(2);
+test('It renders as unchecked when the groupValue is different than the value', function(assert) {
+  assert.expect(1);
 
-  this.set('label', DEFAULT_LABEL);
-  this.set('checked', true);
+  this.set('groupValue', 'javascript');
+  this.set('value', 'php');
 
-  this.render(hbs`{{uni-radio-button label=label checked=checked}}`);
+  this.render(hbs`{{uni-radio-button label=label value=value groupValue=groupValue}}`);
 
-  assert.notEqual(this.$().text().trim(), '');
-  assert.equal(this.$('label').text().trim(), DEFAULT_LABEL);
+  assert.dom('.uni-radio-button input').isNotChecked();
 });
 
-test('it renders unchecked', function(assert) {
-  assert.expect(2);
+test('It triggers the onClick action with correct arguments', async function(assert) {
+  assert.expect(1);
 
-  this.set('label', DEFAULT_LABEL);
-  this.set('checked', false);
+  this.set('groupValue', 'javascript');
+  this.set('value', 'php');
+  this.set('hasChanged', (value) => assert.equal(value, 'php'));
 
-  this.render(hbs`{{uni-radio-button label=label checked=checked}}`);
+  this.render(hbs`{{uni-radio-button label=label value=value groupValue=groupValue hasChanged=hasChanged}}`);
 
-  assert.notEqual(this.$().text().trim(), '');
-  assert.equal(this.$('label').text().trim(), DEFAULT_LABEL);
+  await click('input');
 });


### PR DESCRIPTION
### Why?
The checked property of the radio-button shouldn't be changeable. This property is fully managed by the component. Any parent component is only allowed to change the `groupValue` property, triggering the `checked` computed.

### Further improvements:
See issue https://github.com/uniplaces/ember-cli-uniq/issues/246