### PR TITLE
[RFC][UN-11167] Fix page not becoming scrollable

### DIFF
--- a/addon/components/uni-modal.js
+++ b/addon/components/uni-modal.js
@@ -3,6 +3,8 @@ import { observer } from '@ember/object';
 import $ from 'jquery';
 import layout from '../templates/components/uni-modal';
 
+const OVERFLOW_HIDDEN_CLASS = 'overflow-hidden';
+
 export default Component.extend({
   tagName: '',
   layout,
@@ -19,10 +21,13 @@ export default Component.extend({
 
   // This observer is used to bypass the scroll on mobile when a modal is open
   onOpenChangeObserver: observer('isOpen', function() {
-    let overflowClass = 'overflow-hidden';
-
-    this.get('isOpen') ? $('body').addClass(overflowClass) : $('body').removeClass(overflowClass);
+    this.get('isOpen') ? $('body').addClass(OVERFLOW_HIDDEN_CLASS) : $('body').removeClass(OVERFLOW_HIDDEN_CLASS);
   }),
+
+  didDestroyElement() {
+    this._super(...arguments);
+    $('body').removeClass(OVERFLOW_HIDDEN_CLASS);
+  },
 
   actions: {
     onCloseModal() {

--- a/addon/components/uni-modal.js
+++ b/addon/components/uni-modal.js
@@ -3,30 +3,32 @@ import { observer } from '@ember/object';
 import $ from 'jquery';
 import layout from '../templates/components/uni-modal';
 
-const OVERFLOW_HIDDEN_CLASS = 'overflow-hidden';
-
 export default Component.extend({
   tagName: '',
   layout,
   baseCssClass: 'uni-modal',
   modifierCssClass: '',
-
-  title: null,
   customCssComponentClass: '',
+  bodyOverflowClass: 'overflow-hidden',
+  title: null,
   hasSeparator: true,
   hasCloseButton: true,
   renderInPlace: false,
   isOpen: null,
+
   onCloseModal() {},
 
   // This observer is used to bypass the scroll on mobile when a modal is open
   onOpenChangeObserver: observer('isOpen', function() {
-    this.get('isOpen') ? $('body').addClass(OVERFLOW_HIDDEN_CLASS) : $('body').removeClass(OVERFLOW_HIDDEN_CLASS);
+    this.get('isOpen')
+      ? $('body').addClass(this.get('bodyOverflowClass'))
+      : $('body').removeClass(this.get('bodyOverflowClass'));
   }),
 
   didDestroyElement() {
     this._super(...arguments);
-    $('body').removeClass(OVERFLOW_HIDDEN_CLASS);
+
+    $('body').removeClass(this.get('bodyOverflowClass'));
   },
 
   actions: {


### PR DESCRIPTION
## Context

- Right now, if we have the ```uni-modal``` visible and change the route, the page doesn't become scrollable when it should. To do that, we'd need to toggle the property ```isOpen``` before redirecting to it. I think this behaviour is not expected and the logic should live inside the ```uni-modal``` component itself.