### PR TITLE
[RFC][NI] Add Enumerable super-class

### DIFF
--- a/addon/enums/availability-options-type.js
+++ b/addon/enums/availability-options-type.js
@@ -1,6 +1,6 @@
-import EmberObject from '@ember/object';
+import Enumerable from './enumerable';
 
-export default EmberObject.create({
+export default Enumerable.create({
   NONE: 'none',
   LOW: 'low',
   MEDIUM: 'medium',

--- a/addon/enums/country-codes-type.js
+++ b/addon/enums/country-codes-type.js
@@ -1,6 +1,6 @@
-import EmberObject from '@ember/object';
+import Enumerable from './enumerable';
 
-export default EmberObject.create({
+export default Enumerable.create({
   AT: 'AT',
   BE: 'BE',
   DE: 'DE',

--- a/addon/enums/currency-symbol-type.js
+++ b/addon/enums/currency-symbol-type.js
@@ -1,6 +1,6 @@
-import EmberObject from '@ember/object';
+import Enumerable from './enumerable';
 
-export default EmberObject.create({
+export default Enumerable.create({
   EUR: '€',
   GBP: '£',
   USD: '$',

--- a/addon/enums/enumerable.js
+++ b/addon/enums/enumerable.js
@@ -1,0 +1,25 @@
+import EmberObject from '@ember/object';
+
+export default EmberObject.extend({
+  toKeyValueJson() {
+    return Object.keys(this).reduce((json, key) => {
+      if (typeof this[key] === 'function') {
+        return json;
+      }
+
+      json.pushObject({ key, value: this[key] });
+
+      return json;
+    }, []);
+  },
+
+  values() {
+    return Object.keys(this).reduce((values, key) => {
+      if (typeof this[key] === 'function') {
+        return values;
+      }
+
+      return values.concat(this[key]);
+    }, []);
+  }
+});

--- a/addon/enums/input-type.js
+++ b/addon/enums/input-type.js
@@ -1,6 +1,6 @@
-import EmberObject from '@ember/object';
+import Enumerable from './enumerable';
 
-export default EmberObject.create({
+export default Enumerable.create({
   TEXT: 'text',
   NUMBER: 'number',
   EMAIL: 'email'

--- a/addon/enums/key-codes-type.js
+++ b/addon/enums/key-codes-type.js
@@ -1,6 +1,6 @@
-import EmberObject from '@ember/object';
+import Enumerable from './enumerable';
 
-export default EmberObject.create({
+export default Enumerable.create({
   BACKSPACE: 8,
   TAB: 9,
   ENTER: 13,

--- a/addon/enums/phone-number-validation-type.js
+++ b/addon/enums/phone-number-validation-type.js
@@ -1,5 +1,5 @@
-import EmberObject from '@ember/object';
+import Enumerable from './enumerable';
 
-export default EmberObject.create({
+export default Enumerable.create({
   PT: /^(?:[92]\d{2}(?:\s?\d{3}){2})$/
 });

--- a/addon/enums/photo-size-types.js
+++ b/addon/enums/photo-size-types.js
@@ -1,6 +1,6 @@
-import EmberObject from '@ember/object';
+import Enumerable from './enumerable';
 
-export default EmberObject.create({
+export default Enumerable.create({
   ORIGINAL: 'original',
   XX_LARGE: 'xx-large',
   X_LARGE: 'x-large',

--- a/addon/enums/uni-alert-type.js
+++ b/addon/enums/uni-alert-type.js
@@ -1,6 +1,6 @@
-import EmberObject from '@ember/object';
+import Enumerable from './enumerable';
 
-export default EmberObject.create({
+export default Enumerable.create({
   SUCCESS: 'success',
   WARNING: 'warning',
   ERROR: 'error'


### PR DESCRIPTION
NI

### Motivation:
In every new project, we're always including (i.e. copy+paste) the `types.js` file containing a super class to empower our `EmberObject`s that represent enumerables.

Therefore, I decided to add `enumerable.js` -- an EmberObject sub-class and copy of `types.js`-- and have all enumerables inherit from it.

From now on, `enumerable.js` should be used and `types.js` is from this PR on deprecated. The release containing this PR must have a migration guide, although this is not a breaking change, but rather an additional functionality.