### PR TITLE
[RFC][UN-14546] Add transform opt in to-money helper

### DIFF
--- a/addon/helpers/to-money.js
+++ b/addon/helpers/to-money.js
@@ -1,5 +1,5 @@
-import { isEmpty } from '@ember/utils';
 import Helper from '@ember/component/helper';
+import { isEmpty, isPresent } from '@ember/utils';
 import { inject as service } from '@ember/service';
 import toMoney from 'ember-cli-uniq/utils/to-money';
 
@@ -8,16 +8,15 @@ const DEFAULT_LOCALE = 'en-gb';
 export default Helper.extend({
   i18n: service('i18n'),
 
-  compute([params]) {
-    let i18n = this.get('i18n');
-
+  compute([params], namedArgs) {
     if (isEmpty(params)) {
       return '';
     }
 
-    let locale = i18n.get('locale') || DEFAULT_LOCALE;
-    let { amount, currency_code } = params;
+    const locale = this.get('i18n.locale') || DEFAULT_LOCALE;
+    const { amount, currency_code } = params;
+    const transformedAmount = isPresent(namedArgs.transform) && !namedArgs.transform ? amount * 100 : amount;
 
-    return toMoney(amount, currency_code, locale);
+    return toMoney(transformedAmount, currency_code, locale);
   }
 });

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -177,6 +177,10 @@ export default Route.extend({
       moneyExample: {
         amount: 100000,
         currency_code: 'EUR'
+      },
+      moneyTransformedExample: {
+        amount: 2500,
+        currency_code: 'EUR'
       }
     };
   },

--- a/tests/dummy/app/templates/components/demo-page.hbs
+++ b/tests/dummy/app/templates/components/demo-page.hbs
@@ -661,11 +661,16 @@
       <div class="component">
         {{uni-title title="to-money"}}
         <p class="description">
-          This helper is used to convert money-value objects into strings to display to the user.
+          This helper is used to convert money-pattern objects into strings to display to the user.<br/>
+          It has an option <b>transform</b>, true by default. If false, it'll not transform the money-pattern
+          amount into displayable amount, as it's already transformed.
         </p>
 
         {{to-money model.moneyExample}}
         {{code-snippet name="to-money-1.hbs"}}
+
+        {{to-money model.moneyTransformedExample}}
+        {{code-snippet name="to-money-2.hbs"}}
       </div>
     </div>
   </div>

--- a/tests/dummy/app/templates/components/demo-page.hbs
+++ b/tests/dummy/app/templates/components/demo-page.hbs
@@ -669,7 +669,7 @@
         {{to-money model.moneyExample}}
         {{code-snippet name="to-money-1.hbs"}}
 
-        {{to-money model.moneyTransformedExample}}
+        {{to-money model.moneyTransformedExample transform=false}}
         {{code-snippet name="to-money-2.hbs"}}
       </div>
     </div>

--- a/tests/dummy/app/templates/snippets/to-money-1.hbs
+++ b/tests/dummy/app/templates/snippets/to-money-1.hbs
@@ -1,1 +1,2 @@
-{{to-money moneyValueObject}}
+{{!-- money: { amount: 100000, currency_code: 'EUR'} --}}
+{{to-money money}}

--- a/tests/dummy/app/templates/snippets/to-money-2.hbs
+++ b/tests/dummy/app/templates/snippets/to-money-2.hbs
@@ -1,0 +1,2 @@
+{{!-- money: { amount: 2500, currency_code: 'EUR'} --}}
+{{to-money money transform=false}}

--- a/tests/integration/helpers/to-money-test.js
+++ b/tests/integration/helpers/to-money-test.js
@@ -22,3 +22,19 @@ test('It renders', function(assert) {
 
   assert.ok(this.$().text().trim().includes('100'));
 });
+
+test('It renders transformed', function(assert) {
+  this.set('money', { amount: 10000, currency_code: 'EUR' });
+
+  this.render(hbs`{{to-money money transform=true}}`);
+
+  assert.ok(this.$().text().trim().includes('100'));
+});
+
+test('It renders non-transformed', function(assert) {
+  this.set('money', { amount: 100, currency_code: 'EUR' });
+
+  this.render(hbs`{{to-money money transform=false}}`);
+
+  assert.ok(this.$().text().trim().includes('100'));
+});


### PR DESCRIPTION
### Context:

Add transform option in to-money helper that allows displaying money values without converting the `amount` from money-pattern to displayable

### Screenshots:
![screen shot 2018-10-04 at 18 46 00](https://user-images.githubusercontent.com/5813769/46492564-d9d7f280-c805-11e8-898a-fbb859a7a48c.png)
