### PR TITLE
[RFC][NI] Remove uni-checkbox's two-way-data-binding

### DIFF
--- a/addon/components/uni-checkbox.js
+++ b/addon/components/uni-checkbox.js
@@ -12,8 +12,6 @@ export default Component.extend({
   onChange() {},
 
   change() {
-    this.toggleProperty('isSelected');
-    this.get('onChange')(this.get('isSelected'));
+    this.get('onChange')(!this.get('isSelected'));
   }
 });
-

--- a/addon/components/uni-checkbox.js
+++ b/addon/components/uni-checkbox.js
@@ -12,6 +12,6 @@ export default Component.extend({
   onChange() {},
 
   change() {
-    this.get('onChange')(!this.get('isSelected'));
+    this.get('onChange')(!this.get('isSelected'), ...arguments);
   }
 });

--- a/addon/templates/components/uni-checkbox.hbs
+++ b/addon/templates/components/uni-checkbox.hbs
@@ -9,7 +9,7 @@
     class={{i
       "uni-checkbox ${disabledClass} ${errorClass} ${smallClass}"
       disabledClass=(if isDisabled "uni-checkbox--disabled" "")
-      smallClass=(if isSmall "uni-checkbox--small")
+      smallClass=(if isSmall "uni-checkbox--small" "")
       errorClass=(if hasError "uni-checkbox--error" "")}}>
 
   <label for={{i "${id}-checkbox" id=elementId}}>

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -5,6 +5,7 @@ import moment from 'moment';
 export default Route.extend({
   model() {
     return {
+      isCheckboxSelected: false,
       checked: false,
       options: ['A', 'B', 'C'],
       isOpen: true,

--- a/tests/dummy/app/templates/components/demo-page.hbs
+++ b/tests/dummy/app/templates/components/demo-page.hbs
@@ -188,6 +188,10 @@
           {{uni-checkbox label="Disabled checkbox" isDisabled=true}}
           {{uni-checkbox label="Checkbox with error" hasError=true}}
           {{uni-checkbox label="Checkbox with icon" icon="check"}}
+          {{uni-checkbox
+            label="Checkbox with onChange hook"
+            isSelected=model.isCheckboxSelected
+            onChange=(action (mut model.isCheckboxSelected))}}
         </div>
         {{code-snippet name="uni-checkbox-1.hbs"}}
       </div>

--- a/tests/dummy/app/templates/snippets/uni-checkbox-1.hbs
+++ b/tests/dummy/app/templates/snippets/uni-checkbox-1.hbs
@@ -2,3 +2,7 @@
 {{uni-checkbox label="Not selected" isSelected=false}}
 {{uni-checkbox label="Disabled checkbox" isDisabled=true}}
 {{uni-checkbox label="Checkbox with error" hasError=true}}
+{{uni-checkbox
+  label="Checkbox with onChange hook"
+  isSelected=isCheckboxSelected
+  onChange=(action (mut isCheckboxSelected))}}

--- a/tests/integration/components/uni-checkbox-test.js
+++ b/tests/integration/components/uni-checkbox-test.js
@@ -1,30 +1,24 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | uni checkbox', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function(assert) {
-    assert.expect(1);
-
     await render(hbs`{{uni-checkbox}}`);
 
     assert.dom('.uni-checkbox').exists();
   });
 
   test('it and puts small class', async function(assert) {
-    assert.expect(1);
-
     await render(hbs`{{uni-checkbox isSmall=true}}`);
 
     assert.dom('.uni-checkbox').hasClass('uni-checkbox--small');
   });
 
   test('it renders icon', async function(assert) {
-    assert.expect(1);
-
     await render(hbs`{{uni-checkbox icon="check"}}`);
 
     assert.dom('.icon').exists();
@@ -37,24 +31,25 @@ module('Integration | Component | uni checkbox', function(hooks) {
     await click('.uni-checkbox');
 
     assert.notOk(this.get('isSelected'), 'it doesn\'t mutate isSelected');
-    assert.dom('.uni-checkbox').isNotChecked();
+    assert.dom('.uni-checkbox').isChecked('it doesn\'t prevent default');
   });
 
   test('it calls onChange with the new value', async function(assert) {
-    assert.expect(4);
+    assert.expect(5);
 
     this.setProperties({
       isSelected: false,
       label: 'This is a label',
-      onChange: (selected) => {
+      onChange: (selected, ev) => {
         assert.ok(true, 'it calls onChange');
         assert.ok(selected, 'it passes the new value to onChange');
+        assert.ok(ev, 'it passes the event to onChange')
 
         this.set('isSelected', selected);
       }
     });
 
-    await render(hbs`{{uni-checkbox isSelected=isSelected label=label}}`);
+    await render(hbs`{{uni-checkbox isSelected=isSelected label=label onChange=onChange}}`);
     await click('.uni-checkbox');
 
     assert.ok(this.get('isSelected'), 'it mutates isSelected using DDAU');

--- a/tests/integration/components/uni-checkbox-test.js
+++ b/tests/integration/components/uni-checkbox-test.js
@@ -29,4 +29,35 @@ module('Integration | Component | uni checkbox', function(hooks) {
 
     assert.dom('.icon').exists();
   });
+
+  test('it does not mutate isSelected automatically', async function(assert) {
+    this.setProperties({ isSelected: false, label: 'This is a label' });
+
+    await render(hbs`{{uni-checkbox isSelected=isSelected label=label}}`);
+    await click('.uni-checkbox');
+
+    assert.notOk(this.get('isSelected'), 'it doesn\'t mutate isSelected');
+    assert.dom('.uni-checkbox').isNotChecked();
+  });
+
+  test('it calls onChange with the new value', async function(assert) {
+    assert.expect(4);
+
+    this.setProperties({
+      isSelected: false,
+      label: 'This is a label',
+      onChange: (selected) => {
+        assert.ok(true, 'it calls onChange');
+        assert.ok(selected, 'it passes the new value to onChange');
+
+        this.set('isSelected', selected);
+      }
+    });
+
+    await render(hbs`{{uni-checkbox isSelected=isSelected label=label}}`);
+    await click('.uni-checkbox');
+
+    assert.ok(this.get('isSelected'), 'it mutates isSelected using DDAU');
+    assert.dom('.uni-checkbox').isChecked();
+  });
 });


### PR DESCRIPTION
### What?
Remove `uni-checkbox`'s two-way data-binding.

### Why?
This can cause unexpected behaviours in the code like setting the value of what used to be a computed property. There are also some situations where we need to trigger some action that will then resolve the value for checking if the checkbox is selected