### PR TITLE
[RFC][NI] Remove ember-i18n dependency and conditionally fetch locale

### DIFF
--- a/addon/helpers/to-money.js
+++ b/addon/helpers/to-money.js
@@ -1,19 +1,32 @@
 import Helper from '@ember/component/helper';
+import { getOwner } from '@ember/application';
 import { isEmpty, isPresent } from '@ember/utils';
-import { inject as service } from '@ember/service';
 import toMoney from 'ember-cli-uniq/utils/to-money';
 
 const DEFAULT_LOCALE = 'en-gb';
 
 export default Helper.extend({
-  i18n: service('i18n'),
+  _getLocale() {
+    let owner = getOwner(this);
+    let intlService = owner.lookup('service:intl');
+    if (isPresent(intlService)) {
+      return intlService.get('primaryLocale');
+    }
+
+    let i18nService = owner.lookup('service:i18n');
+    if (isPresent(i18nService)) {
+      return i18nService.get('locale');
+    }
+
+    return DEFAULT_LOCALE;
+  },
 
   compute([params], namedArgs) {
     if (isEmpty(params)) {
       return '';
     }
 
-    let locale = this.get('i18n.locale') || DEFAULT_LOCALE;
+    let locale = this._getLocale();
     let { amount, currency_code } = params;
     let transformedAmount = isPresent(namedArgs.transform) && !namedArgs.transform ? amount * 100 : amount;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5806,41 +5806,6 @@
         "ember-factory-for-polyfill": "^1.3.1"
       }
     },
-    "ember-i18n": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/ember-i18n/-/ember-i18n-5.3.0.tgz",
-      "integrity": "sha512-YzLcd7vWNPjDbQk7n/Nze3cPKNvC14zlFKsBOxJIDjfEDqts3j7GKbF99R5Pvl6JqUhh5MlIPFzIiWST00IJFQ==",
-      "dev": true,
-      "requires": {
-        "broccoli-funnel": "^2.0.1",
-        "ember-cli-babel": "^6.11.0",
-        "ember-cli-version-checker": "^2.1.0",
-        "ember-getowner-polyfill": "^2.2.0"
-      },
-      "dependencies": {
-        "ember-cli-babel": {
-          "version": "6.17.2",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.17.2.tgz",
-          "integrity": "sha512-9KcCvF1PcelEFTSiJ/Ld20tfuW9acMkwHC/xINLsmwqJVDbm3oEqWtiFDZ5ebaC278O5I0GqNJWJLYNoWMNZ8g==",
-          "dev": true,
-          "requires": {
-            "amd-name-resolver": "1.2.0",
-            "babel-plugin-debug-macros": "^0.2.0-beta.6",
-            "babel-plugin-ember-modules-api-polyfill": "^2.5.0",
-            "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
-            "babel-polyfill": "^6.26.0",
-            "babel-preset-env": "^1.7.0",
-            "broccoli-babel-transpiler": "^6.5.0",
-            "broccoli-debug": "^0.6.4",
-            "broccoli-funnel": "^2.0.0",
-            "broccoli-source": "^1.1.0",
-            "clone": "^2.0.0",
-            "ember-cli-version-checker": "^2.1.2",
-            "semver": "^5.5.0"
-          }
-        }
-      }
-    },
     "ember-ignore-children-helper": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ember-ignore-children-helper/-/ember-ignore-children-helper-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "ember-code-snippet": "^2.3.1",
     "ember-composable-helpers": "2.1.0",
     "ember-disable-prototype-extensions": "^1.1.3",
-    "ember-i18n": "^5.3.0",
     "ember-keyboard": "^4.0.0",
     "ember-load-initializers": "^2.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -48,9 +48,5 @@ module.exports = function(environment) {
     ENV.rootURL = '/ember-cli-uniq/';
   }
 
-  ENV.i18n = {
-    defaultLocale: 'en-gb'
-  };
-
   return ENV;
 };

--- a/tests/integration/helpers/interpolate-test.js
+++ b/tests/integration/helpers/interpolate-test.js
@@ -3,10 +3,10 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('helper:interpolate', function(hooks) {
+module('Integration | Helper | interpolate', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('interpolates values from string', async function(assert) {
+  test('it interpolates values from string', async function(assert) {
     this.set('toBeInterpolated', '${b}');
 
     await render(hbs`{{i toBeInterpolated b='cat' d='fish'}}`);

--- a/tests/integration/helpers/to-money-test.js
+++ b/tests/integration/helpers/to-money-test.js
@@ -43,7 +43,7 @@ module('Integration | Helper | to money', function(hooks) {
     assert.dom(this.element).hasText('£2500');
   });
 
-  test('it superseds intl service defined', async function(assert) {
+  test('it renders with both services defined with intl supersedding i18n', async function(assert) {
     this.owner.register('service:intl', StubIntlService);
     this.owner.register('service:i18n', StubI18nService);
 

--- a/tests/integration/helpers/to-money-test.js
+++ b/tests/integration/helpers/to-money-test.js
@@ -6,38 +6,67 @@ import hbs from 'htmlbars-inline-precompile';
 import Service from '@ember/service';
 
 let StubI18nService = Service.extend({
-  locale: 'en-gb'
+  locale: 'pt-pt'
 });
+let StubIntlService = Service.extend({
+  primaryLocale: 'en-gb'
+})
 
 module('Integration | Helper | to money', function(hooks) {
   setupRenderingTest(hooks);
 
-  hooks.beforeEach(function() {
-    this.owner.register('service:i18n', StubI18nService);
-    this.i18n = this.owner.lookup('service:i18n');
+  test('it renders without any service defined', async function(assert) {
+    this.set('money', { amount: 10000, currency_code: 'BRL' });
+
+    await render(hbs`{{to-money money}}`);
+
+    assert.dom(this.element).hasText('R$100');
   });
 
-  test('It renders', async function(assert) {
+  test('it renders with only i18n service defined', async function(assert) {
+    this.owner.register('service:i18n', StubI18nService);
+
     this.set('money', { amount: 10000, currency_code: 'EUR' });
 
     await render(hbs`{{to-money money}}`);
 
-    assert.dom(this.element).includesText('100');
+    assert.dom(this.element).hasText('100€');
   });
 
-  test('It renders transformed', async function(assert) {
-    this.set('money', { amount: 10000, currency_code: 'EUR' });
+  test('it renders with only intl service defined', async function(assert) {
+    this.owner.register('service:intl', StubIntlService);
+
+    this.set('money', { amount: 250000, currency_code: 'GBP' });
+
+    await render(hbs`{{to-money money}}`);
+
+    assert.dom(this.element).hasText('£2500');
+  });
+
+  test('it superseds intl service defined', async function(assert) {
+    this.owner.register('service:intl', StubIntlService);
+    this.owner.register('service:i18n', StubI18nService);
+
+    this.set('money', { amount: 250000, currency_code: 'GBP' });
+
+    await render(hbs`{{to-money money}}`);
+
+    assert.dom(this.element).hasText('£2500');
+  });
+
+  test('it renders transformed', async function(assert) {
+    this.set('money', { amount: 10000, currency_code: 'USD' });
 
     await render(hbs`{{to-money money transform=true}}`);
 
-    assert.dom(this.element).includesText('100');
+    assert.dom(this.element).hasText('US$100');
   });
 
-  test('It renders non-transformed', async function(assert) {
-    this.set('money', { amount: 100, currency_code: 'EUR' });
+  test('it renders non-transformed', async function(assert) {
+    this.set('money', { amount: 2450, currency_code: 'USD' });
 
     await render(hbs`{{to-money money transform=false}}`);
 
-    assert.dom(this.element).includesText('100');
+    assert.dom(this.element).hasText('US$2450');
   });
 });


### PR DESCRIPTION
### What?
Remove ember-i18n (and any ember internationalisation add-on) dependency by conditionally loading the expected service and, most importantly, not making any breaking change. For more information, [visit Ember.js documentation](https://guides.emberjs.com/v3.8.0/applications/services/#toc_accessing-services)

### Why?
Right now, we have a strict dependency on `ember-i18n`. However, this add-on has been deprecated in favour of `ember-intl`.

Some projects were already migrated to `ember-intl`, specially to enable asynchronous load of the translations. In those projects, the solution has been to create a new `to-money` helper that does exactly the same as this one with the catch that it uses the `intl` service from `ember-intl` instead of the `i18n` service from `ember-i18n`.