### PR TITLE
[RFC][SUP-379] Add rel attribute binding on uni-anchor component

### DIFF
--- a/addon/components/uni-anchor.js
+++ b/addon/components/uni-anchor.js
@@ -6,6 +6,6 @@ export default Component.extend({
   layout,
 
   tagName: 'a',
-  attributeBindings: ['href', 'target'],
-  href: '#'
+  attributeBindings: ['href', 'target', 'rel'],
+  href: '#',
 });

--- a/tests/integration/components/uni-anchor-test.js
+++ b/tests/integration/components/uni-anchor-test.js
@@ -4,18 +4,21 @@ import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 const DEFAULT_LABEL = 'This is a label';
+const DEFAULT_REL = 'noopener noreferrer';
 
 module('Integration | Component | uni anchor', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function(assert) {
-    assert.expect(2);
+    assert.expect(3);
 
     this.set('label', DEFAULT_LABEL);
+    this.set('rel', DEFAULT_REL);
 
-    await render(hbs`{{uni-anchor label=label}}`);
+    await render(hbs`{{uni-anchor label=label rel=rel}}`);
 
     assert.dom('.uni-anchor').exists();
     assert.dom('.uni-anchor').hasText(DEFAULT_LABEL);
+    assert.dom('.uni-anchor').hasAttribute('rel', DEFAULT_REL);
   });
 });


### PR DESCRIPTION
- With this implementation, the uni-anchor component will allow the optional use of the **`rel`** attribute

For example: `rel="noopener noreferrer"`
